### PR TITLE
docs: simplify config guide — remove gene.yaml as primary option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ docker compose -f docker-compose.dev.yml up      # Dev with hot reload
 
 **LLM gateway** — Single `AsyncOpenAI` client for all providers. `gateway/registry.py` maps provider names to `ProviderConfig` (base_url + api_key_field). Adding a provider = one dict entry in `PROVIDER_REGISTRY`.
 
-**Config cascade** — `config/models.py` `GeneConfig` uses pydantic-settings: constructor args > env vars (`GENE_*` prefix) > `gene.yaml`.
+**Config cascade** — `config/models.py` `GeneConfig` uses pydantic-settings: constructor args > env vars (`GENE_*` prefix) > `gene.yaml` (legacy, optional).
 
 **Storage** — SQLAlchemy 2.0 async ORM (`storage/models.py`). SQLite default, PostgreSQL optional. Schema auto-migrated via `ensure_columns()` on startup (no Alembic at runtime).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,10 +1,11 @@
 # Configuration Guide
 
-Helix uses a three-layer configuration cascade (highest priority first):
+Helix is configured through environment variables (`.env` file) and the **Settings UI** in the web interface.
 
-1. **Constructor args / CLI flags** — override everything
-2. **Environment variables** — `GENE_` prefix
-3. **gene.yaml file** — lowest priority defaults
+- **`.env` file** — API keys, database URL, default models (set once at startup)
+- **Settings UI** — API keys, model/provider per role, temperature, concurrency (editable at runtime)
+- **Config tab** — per-prompt model and inference overrides
+- **Evolution tab** — per-run parameter overrides
 
 ## Quick Start
 
@@ -128,29 +129,6 @@ Optional — for cold-start trace import only.
 |----------|-------------|---------|
 | `GENE_CONCURRENCY_LIMIT` | Max concurrent LLM calls | `10` |
 | `GENE_PROMPTS_DIR` | Directory for prompt files | `./prompts` |
-
-## gene.yaml
-
-Alternative to environment variables. Place at project root:
-
-```yaml
-gemini_api_key: your-key-here
-
-meta_model: gemini-2.5-flash
-meta_provider: gemini
-target_model: gemini-3-flash-preview
-target_provider: gemini
-judge_model: gemini-2.5-flash
-judge_provider: gemini
-
-database_url: sqlite+aiosqlite:///helix.db
-
-generation:
-  temperature: 0.7
-  max_tokens: 4096
-```
-
-Environment variables override gene.yaml values.
 
 ## Docker Configuration
 


### PR DESCRIPTION
## Summary

- Remove `gene.yaml` section from Configuration docs — it's redundant with `.env` + Settings UI
- Update config intro to clearly explain the 4 config layers users actually use: `.env`, Settings UI, Config tab, Evolution tab
- Mark gene.yaml as legacy in CLAUDE.md

gene.yaml support still works in the code for backwards compatibility, but is no longer promoted to new users.

## Test plan
- [x] Verify docs read clearly without gene.yaml section
- [x] Verify gene.yaml still works if someone uses it (no code changes)


🤖 Generated with [Claude Code](https://claude.com/claude-code)