### PR TITLE
fix: prevent duplicate versions when accepting run results

### DIFF
--- a/api/registry/service.py
+++ b/api/registry/service.py
@@ -400,12 +400,16 @@ class PromptRegistry:
         Inserts a new PromptVersion row with version = max(existing) + 1,
         sets it as the active version, and updates Prompt.template.
 
+        Idempotent: if the latest version already has the same template,
+        returns it instead of creating a duplicate.
+
         Args:
             prompt_id: The prompt identifier.
             template: The template text for the new version.
 
         Returns:
-            Dict with version number, template text, and created_at ISO string.
+            Dict with version number, template text, created_at ISO string,
+            and ``already_existed`` boolean.
 
         Raises:
             PromptNotFoundError: If the prompt does not exist.
@@ -418,6 +422,29 @@ class PromptRegistry:
             prompt_row = result.scalar_one_or_none()
             if prompt_row is None:
                 raise PromptNotFoundError(f"Prompt '{prompt_id}' not found")
+
+            # Check if the latest version already has the same template
+            latest = await session.execute(
+                select(PromptVersion)
+                .where(PromptVersion.prompt_id == prompt_id)
+                .order_by(PromptVersion.version.desc())
+                .limit(1)
+            )
+            latest_row = latest.scalar_one_or_none()
+            if latest_row is not None and latest_row.template == template:
+                logger.info(
+                    "Version %d for prompt '%s' already matches, skipping duplicate",
+                    latest_row.version,
+                    prompt_id,
+                )
+                return {
+                    "version": latest_row.version,
+                    "template": template,
+                    "created_at": latest_row.created_at.isoformat()
+                    if latest_row.created_at
+                    else datetime.now(UTC).isoformat(),
+                    "already_existed": True,
+                }
 
             # Create next version and set as active
             new_ver = await self._create_next_version(session, prompt_id, template)
@@ -435,6 +462,7 @@ class PromptRegistry:
                 "version": new_ver,
                 "template": template,
                 "created_at": datetime.now(UTC).isoformat(),
+                "already_existed": False,
             }
 
     async def list_versions(self, prompt_id: str) -> list[dict]:

--- a/api/web/routers/prompts.py
+++ b/api/web/routers/prompts.py
@@ -427,6 +427,7 @@ async def accept_version(
     """Accept an evolved template as a new version.
 
     Creates a new version from the provided template and sets it as active.
+    Idempotent: returns the existing version if the template already matches.
     Used after evolution runs to accept the best evolved template.
     """
     result = await registry.create_version(prompt_id, body.template)
@@ -435,4 +436,5 @@ async def accept_version(
         template=result["template"],
         created_at=result["created_at"],
         is_active=True,
+        already_existed=result.get("already_existed", False),
     )

--- a/api/web/schemas.py
+++ b/api/web/schemas.py
@@ -616,6 +616,7 @@ class PromptVersionResponse(BaseModel):
     template: str
     created_at: str
     is_active: bool
+    already_existed: bool = False
 
 
 class AcceptVersionRequest(BaseModel):

--- a/frontend/src/components/evolution/EvolutionDashboard.tsx
+++ b/frontend/src/components/evolution/EvolutionDashboard.tsx
@@ -156,12 +156,15 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
         body: { template },
       }),
     onSuccess: (resp) => {
-      const ver = (resp.data as PromptVersionResponse)?.version
+      const data = resp.data as PromptVersionResponse & { already_existed?: boolean }
+      const ver = data?.version
       setAcceptedVersion(ver ?? -1)
       setAcceptError(null)
-      // Invalidate version queries so VersionHistory refreshes
-      queryClient.invalidateQueries({ queryKey: ['prompt-versions', promptId] })
-      queryClient.invalidateQueries({ queryKey: ['prompts', promptId] })
+      // Only invalidate if a new version was actually created
+      if (!data?.already_existed) {
+        queryClient.invalidateQueries({ queryKey: ['prompt-versions', promptId] })
+        queryClient.invalidateQueries({ queryKey: ['prompts', promptId] })
+      }
     },
     onError: (err) => {
       setAcceptError(err instanceof Error ? err.message : 'Failed to accept version')

--- a/tests/api/test_prompt_versions.py
+++ b/tests/api/test_prompt_versions.py
@@ -353,6 +353,55 @@ class TestAcceptVersionEndpoint:
         assert resp3.json()["version"] == 3
 
 
+class TestAcceptVersionIdempotent:
+    """Accepting the same template twice does not create a duplicate version."""
+
+    async def test_accept_same_template_returns_existing(self, client):
+        """Second accept with the same template returns the existing version."""
+        await _register_prompt(client, "ep-idem", "Template v1")
+
+        resp1 = await client.post(
+            "/api/prompts/ep-idem/versions/accept",
+            json={"template": "Evolved template"},
+        )
+        assert resp1.status_code == 201
+        data1 = resp1.json()
+        assert data1["version"] == 2
+        assert data1["already_existed"] is False
+
+        # Accept again with the same template
+        resp2 = await client.post(
+            "/api/prompts/ep-idem/versions/accept",
+            json={"template": "Evolved template"},
+        )
+        assert resp2.status_code == 201
+        data2 = resp2.json()
+        assert data2["version"] == 2  # Same version, not 3
+        assert data2["already_existed"] is True
+
+        # Verify only 2 versions exist
+        resp_list = await client.get("/api/prompts/ep-idem/versions")
+        versions = resp_list.json()
+        assert len(versions) == 2
+
+    async def test_accept_different_template_creates_new(self, client):
+        """Accept with a different template creates a new version normally."""
+        await _register_prompt(client, "ep-diff", "Template v1")
+
+        resp1 = await client.post(
+            "/api/prompts/ep-diff/versions/accept",
+            json={"template": "Evolved v2"},
+        )
+        assert resp1.json()["version"] == 2
+
+        resp2 = await client.post(
+            "/api/prompts/ep-diff/versions/accept",
+            json={"template": "Evolved v3"},
+        )
+        assert resp2.json()["version"] == 3
+        assert resp2.json()["already_existed"] is False
+
+
 class TestRunResultsPromptId:
     """GET /api/history/run/by-uuid/{uuid}/results includes prompt_id."""
 


### PR DESCRIPTION
## Summary

- Make `create_version()` idempotent: check if the latest version's template already matches before creating a new one
- Add `already_existed` field to `PromptVersionResponse` so the frontend knows whether a new version was created
- Frontend only invalidates version queries when a genuinely new version was created
- 2 new tests verifying idempotent accept behavior

**5 files changed, +88 −5 lines**

## Test plan

- [x] `pytest tests/api/test_prompt_versions.py` — 19 passed (2 new)
- [x] Full `pytest` — 1189 passed
- [x] Browser: Click "Accept as New Version" → shows "Accepted as v1"
- [x] Browser: Navigate away, come back, click again → shows "Accepted as v1" (no v2 created)
- [x] API: Accept different template → creates v2 correctly
- [x] API: Accept same v2 template again → returns v2 with `already_existed: true` (no v3)
- [x] API: `/versions` endpoint confirms correct version count after all operations

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)