### PR TITLE
fix: pluralization bugs and provider name capitalization

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -19,8 +19,10 @@
     "runNumber": "Run #{{number}}"
   },
   "promptLayout": {
-    "vars": "{{count}} vars",
-    "anchors": "{{count}} anchors",
+    "vars_one": "{{count}} var",
+    "vars_other": "{{count}} vars",
+    "anchors_one": "{{count}} anchor",
+    "anchors_other": "{{count}} anchors",
     "missingId": "Missing prompt ID.",
     "notFound": "Prompt not found.",
     "template": "Template",
@@ -39,8 +41,10 @@
     "noPromptsDescription": "Register your first prompt to start evolving it.",
     "newPrompt": "New Prompt",
     "noMatch": "No prompts match your search.",
-    "vars": "{{count}} vars",
-    "anchors": "{{count}} anchors",
+    "vars_one": "{{count}} var",
+    "vars_other": "{{count}} vars",
+    "anchors_one": "{{count}} anchor",
+    "anchors_other": "{{count}} anchors",
     "failedToLoadPrompt": "Failed to load prompt.",
     "promptNotFound": "Prompt not found.",
     "templateVariables": "Template Variables",
@@ -335,8 +339,8 @@
     "provider": "Provider"
   },
   "datasets": {
-    "testCases": "{{count}} test case",
-    "testCases_plural": "{{count}} test cases",
+    "testCases_one": "{{count}} test case",
+    "testCases_other": "{{count}} test cases",
     "generateTests": "Generate Tests",
     "addCase": "Add Case",
     "noTestCasesYet": "No test cases yet",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -68,6 +68,13 @@ const PROVIDER_KEY_FIELDS: Record<string, string> = {
   openrouter: 'openrouter_api_key',
 }
 
+// Display names for providers (proper capitalization)
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  gemini: 'Gemini',
+  openai: 'OpenAI',
+  openrouter: 'OpenRouter',
+}
+
 // Role icon mapping (only icons -- titles/descriptions come from t())
 const ROLE_ICONS: Record<RoleName, React.ReactNode> = {
   meta: <Zap className="h-5 w-5 text-amber-500" />,
@@ -375,7 +382,7 @@ export default function SettingsPage() {
               <div key={provider} className="flex items-center gap-4 flex-wrap sm:flex-nowrap">
                 {/* Provider label */}
                 <div className="w-28 shrink-0">
-                  <span className="font-medium capitalize text-sm">{provider}</span>
+                  <span className="font-medium text-sm">{PROVIDER_DISPLAY_NAMES[provider] ?? provider}</span>
                   {hasKey ? (
                     <Badge variant="secondary" className="ml-2 text-xs">{t('settings.active')}</Badge>
                   ) : (


### PR DESCRIPTION
## Summary

- Fix "1 anchors" → "1 anchor" using i18next `_one`/`_other` plural forms
- Fix "1 vars" → "1 var" (both `promptLayout` and `prompts` namespaces)
- Fix "1 test case" / "2 test cases" (migrated from legacy `_plural` to `_one`/`_other`)
- Fix "Openai" → "OpenAI", "Openrouter" → "OpenRouter" in Settings API Keys section using a display name map instead of CSS `capitalize`

## Test plan

- [x] `npm run test` — 197 passed, 0 failed
- [x] Verified pluralization works for count=0, 1, 5

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)