### PR TITLE
fix: Dataset tab — flag tooltips, tag badges, scorer flags

### DIFF
--- a/frontend/src/components/datasets/CaseList.tsx
+++ b/frontend/src/components/datasets/CaseList.tsx
@@ -31,15 +31,29 @@ function ScorerFlags({ expectedOutput }: { expectedOutput: Record<string, unknow
   const flags: React.ReactNode[] = []
   if (expectedOutput.require_content === true) {
     flags.push(
-      <Badge key="rc" variant="outline" className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20">
+      <Badge key="rc" variant="outline" className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20" title="Require Content — response must not be empty">
         RC
       </Badge>
     )
   }
   if (expectedOutput.match_args != null) {
     flags.push(
-      <Badge key="ma" variant="outline" className="bg-blue-500/10 text-blue-400 border-blue-500/20">
+      <Badge key="ma" variant="outline" className="bg-blue-500/10 text-blue-400 border-blue-500/20" title="Match Args — response must call the expected tool">
         MA
+      </Badge>
+    )
+  }
+  if (expectedOutput.must_contain != null) {
+    flags.push(
+      <Badge key="mc" variant="outline" className="bg-amber-500/10 text-amber-400 border-amber-500/20" title="Must Contain — response must include specific text">
+        MC
+      </Badge>
+    )
+  }
+  if (expectedOutput.behavior_criteria != null) {
+    flags.push(
+      <Badge key="bj" variant="outline" className="bg-purple-500/10 text-purple-400 border-purple-500/20" title="Behavior Judge — LLM evaluates against criteria">
+        BJ
       </Badge>
     )
   }
@@ -188,7 +202,15 @@ export function CaseList({ promptId }: { promptId: string }) {
                   <TableCell>
                     <ScorerFlags expectedOutput={tc.expected_output} />
                   </TableCell>
-                  <TableCell className="text-muted-foreground">{tc.tags?.join(', ') || ''}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {tc.tags?.map((tag) => (
+                        <Badge key={tag} variant="secondary" className="text-xs font-normal">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </TableCell>
                   <TableCell className="text-right">
                     <div className="flex gap-2 justify-end">
                       <Button

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -357,8 +357,8 @@
     "provider": "Provider"
   },
   "datasets": {
-    "testCases": "{{count}} test case",
-    "testCases_plural": "{{count}} test cases",
+    "testCases_one": "{{count}} test case",
+    "testCases_other": "{{count}} test cases",
     "generateTests": "Generate Tests",
     "addCase": "Add Case",
     "noTestCasesYet": "No test cases yet",


### PR DESCRIPTION
## Summary

- Add title tooltips to scorer flag badges (RC = Require Content, MA = Match Args)
- Add MC (Must Contain) and BJ (Behavior Judge) flag badges with tooltips
- Render tags as individual `Badge` components instead of comma-separated plain text
- Fix test case count pluralization using i18next `_one`/`_other`

**Note:** Delete confirmation was already implemented (click Delete → Confirm/Cancel inline).

## Test plan

- [x] `npm run test` — 200 passed, 0 failed
- [x] Hover RC/MA badges shows tooltip explanation
- [x] Tags render as individual badges

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)