### PR TITLE
fix: History run detail — case names, stop reason, reason tooltips

### DIFF
--- a/frontend/src/__tests__/case-results.test.tsx
+++ b/frontend/src/__tests__/case-results.test.tsx
@@ -156,4 +156,29 @@ describe('CaseResultsGrid', () => {
     expect(screen.getByText(/2 passed/i)).toBeInTheDocument()
     expect(screen.getByText(/1 failed/i)).toBeInTheDocument()
   })
+
+  it('displays test case name instead of UUID when caseNames map is provided', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000'
+    const cases: CaseResultData[] = [makeCase({ caseId: uuid, tier: 'normal', passed: true })]
+    const caseNames = new Map([[uuid, 'My Friendly Test Name']])
+    render(<CaseResultsGrid caseResults={cases} caseNames={caseNames} />)
+    expect(screen.getByText('My Friendly Test Name')).toBeInTheDocument()
+    expect(screen.queryByText(uuid)).not.toBeInTheDocument()
+  })
+
+  it('falls back to caseId when no caseNames provided', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000'
+    const cases: CaseResultData[] = [makeCase({ caseId: uuid, tier: 'normal', passed: true })]
+    render(<CaseResultsGrid caseResults={cases} />)
+    expect(screen.getByText(uuid)).toBeInTheDocument()
+  })
+
+  it('adds title attribute with full reason text to reason cell', () => {
+    const longReason = 'This is a very long reason that definitely exceeds the fifty character truncation limit used in the display'
+    const cases: CaseResultData[] = [makeCase({ caseId: 'reason-case', reason: longReason })]
+    render(<CaseResultsGrid caseResults={cases} />)
+    const row = screen.getByText('reason-case').closest('tr')
+    const reasonCell = row?.querySelector('td:last-child')
+    expect(reasonCell).toHaveAttribute('title', longReason)
+  })
 })

--- a/frontend/src/__tests__/summary-cards.test.tsx
+++ b/frontend/src/__tests__/summary-cards.test.tsx
@@ -20,7 +20,7 @@ describe('SummaryCards', () => {
     expect(screen.getByText('Best Fitness')).toBeInTheDocument()
     expect(screen.getByText('Seed Fitness')).toBeInTheDocument()
     expect(screen.getByText('Improvement')).toBeInTheDocument()
-    expect(screen.getByText('Termination')).toBeInTheDocument()
+    expect(screen.getByText('Stop Reason')).toBeInTheDocument()
     expect(screen.getByText('Lineage Events')).toBeInTheDocument()
     expect(screen.getByText('Total Cost')).toBeInTheDocument()
   })
@@ -61,7 +61,7 @@ describe('SummaryCards', () => {
       expect(screen.getByText('Best Fitness')).toBeInTheDocument()
       expect(screen.getByText('Seed Fitness')).toBeInTheDocument()
       expect(screen.getByText('Improvement')).toBeInTheDocument()
-      expect(screen.getByText('Termination')).toBeInTheDocument()
+      expect(screen.getByText('Stop Reason')).toBeInTheDocument()
       expect(screen.getByText('Lineage Events')).toBeInTheDocument()
       expect(screen.getByText('Total Cost')).toBeInTheDocument()
 

--- a/frontend/src/components/evolution/CaseResultsGrid.tsx
+++ b/frontend/src/components/evolution/CaseResultsGrid.tsx
@@ -6,6 +6,7 @@ import { scoreColor } from '../../lib/scoring'
 interface CaseResultsGridProps {
   caseResults: CaseResultData[]
   seedCaseResults?: CaseResultData[]
+  caseNames?: Map<string, string>
 }
 
 const TIER_STYLES: Record<string, string> = {
@@ -186,6 +187,7 @@ function DetailPanel({
 export default function CaseResultsGrid({
   caseResults,
   seedCaseResults = [],
+  caseNames,
 }: CaseResultsGridProps) {
   const { t } = useTranslation()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
@@ -295,8 +297,8 @@ export default function CaseResultsGrid({
                       idx % 2 === 0 ? 'bg-slate-800/50' : 'bg-slate-900/30'
                     } hover:bg-slate-700/30`}
                   >
-                    <td className="px-4 py-3 font-mono text-sm text-slate-300">
-                      {c.caseId}
+                    <td className="px-4 py-3 text-sm text-slate-300" title={c.caseId}>
+                      {caseNames?.get(c.caseId) ?? c.caseId}
                     </td>
                     <td className="px-4 py-3">
                       <span
@@ -318,7 +320,7 @@ export default function CaseResultsGrid({
                     >
                       {c.score.toFixed(3)}
                     </td>
-                    <td className="px-4 py-3 text-sm text-slate-400">
+                    <td className="px-4 py-3 text-sm text-slate-400" title={c.reason}>
                       <span className={`mr-1 font-semibold ${c.passed ? 'text-emerald-400' : 'text-red-400'}`}>
                         {c.passed ? '[PASS]' : '[FAIL]'}
                       </span>

--- a/frontend/src/components/evolution/EvolutionDashboard.tsx
+++ b/frontend/src/components/evolution/EvolutionDashboard.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef, useMemo, lazy, Suspense } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEvolutionSocket } from '../../hooks/useEvolutionSocket'
 import { useRunResults } from '../../hooks/useRunResults'
-import { getRunStatusApiEvolutionRunIdStatusGet, acceptVersionApiPromptsPromptIdVersionsAcceptPost } from '../../client/sdk.gen'
+import { getRunStatusApiEvolutionRunIdStatusGet, acceptVersionApiPromptsPromptIdVersionsAcceptPost, listCasesApiPromptsPromptIdDatasetGet } from '../../client/sdk.gen'
 import type { EvolutionRunStatus, PromptVersionResponse } from '../../client/types.gen'
 import type { EvolutionStatus, SummaryData, GenerationData, CandidateData, LineageNode } from '../../types/evolution'
 import { Badge } from '@/components/ui/badge'
@@ -146,6 +146,21 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
 
   // Accept as new version
   const promptId = results?.promptId ?? null
+
+  // Fetch test case names for the prompt so we can display them instead of UUIDs
+  const { data: testCasesResp } = useQuery({
+    queryKey: ['dataset-cases', promptId],
+    queryFn: () => listCasesApiPromptsPromptIdDatasetGet({ path: { prompt_id: promptId! } }),
+    enabled: !!promptId,
+    staleTime: 5 * 60 * 1000,
+  })
+  const caseNames = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const tc of testCasesResp?.data ?? []) {
+      if (tc.name) map.set(tc.id, tc.name)
+    }
+    return map
+  }, [testCasesResp])
   const [acceptedVersion, setAcceptedVersion] = useState<number | null>(null)
   const [acceptError, setAcceptError] = useState<string | null>(null)
 
@@ -400,6 +415,7 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
               <CaseResultsGrid
                 caseResults={results?.caseResults ?? []}
                 seedCaseResults={results?.seedCaseResults ?? []}
+                caseNames={caseNames}
               />
             </div>
           )}

--- a/frontend/src/components/evolution/SummaryCards.tsx
+++ b/frontend/src/components/evolution/SummaryCards.tsx
@@ -50,7 +50,7 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
       borderClass: 'border-l-blue-400',
     },
     {
-      label: t('evolution.termination'),
+      label: t('evolution.stopReason'),
       value: (() => {
         const r = data.terminationReason
         if (!r) return t('evolution.running')

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -212,6 +212,7 @@
     "seedFitness": "Seed Fitness",
     "improvement": "Improvement",
     "termination": "Termination",
+    "stopReason": "Stop Reason",
     "lineageEvents": "Lineage Events",
     "totalCost": "Total Cost",
     "running": "Running...",


### PR DESCRIPTION
## Summary

- **Case Results**: Show test case names instead of raw UUIDs (fetches dataset, maps IDs to names, falls back to UUID with title tooltip)
- **Summary Cards**: Rename "TERMINATION" → "Stop Reason" (less alarming)
- **Reason column**: Add `title` tooltip showing full untruncated reason text on hover
- 3 new tests covering name display, UUID fallback, and reason tooltips

## Test plan

- [x] `npm run test` — 203 passed, 0 failed (3 new)
- [x] Case Results shows test case names when available
- [x] "Stop Reason" label instead of "TERMINATION"
- [x] Hover reason text shows full content

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)