### PR TITLE
fix: cross-page consistency — wizard back, pluralization, playground model

### DIFF
--- a/frontend/src/components/wizard/WizardFlow.tsx
+++ b/frontend/src/components/wizard/WizardFlow.tsx
@@ -103,14 +103,17 @@ export function WizardFlow() {
       {/* Navigation buttons (not on Review step - it has its own buttons) */}
       {step < 3 && (
         <div className="flex justify-between mt-6">
-          <Button
-            variant="outline"
-            onClick={handleBack}
-            disabled={step === 0}
-          >
-            <ChevronLeft className="h-4 w-4 mr-1" />
-            {t('common.back')}
-          </Button>
+          {step > 0 ? (
+            <Button
+              variant="outline"
+              onClick={handleBack}
+            >
+              <ChevronLeft className="h-4 w-4 mr-1" />
+              {t('common.back')}
+            </Button>
+          ) : (
+            <div />
+          )}
           <Button
             onClick={handleNext}
             disabled={!isStepValid(step, data)}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -19,8 +19,10 @@
     "runNumber": "Run #{{number}}"
   },
   "promptLayout": {
-    "vars": "{{count}} vars",
-    "anchors": "{{count}} anchors",
+    "vars_one": "{{count}} var",
+    "vars_other": "{{count}} vars",
+    "anchors_one": "{{count}} anchor",
+    "anchors_other": "{{count}} anchors",
     "missingId": "Missing prompt ID.",
     "notFound": "Prompt not found.",
     "template": "Template",
@@ -39,8 +41,10 @@
     "noPromptsDescription": "Register your first prompt to start evolving it.",
     "newPrompt": "New Prompt",
     "noMatch": "No prompts match your search.",
-    "vars": "{{count}} vars",
-    "anchors": "{{count}} anchors",
+    "vars_one": "{{count}} var",
+    "vars_other": "{{count}} vars",
+    "anchors_one": "{{count}} anchor",
+    "anchors_other": "{{count}} anchors",
     "failedToLoadPrompt": "Failed to load prompt.",
     "promptNotFound": "Prompt not found.",
     "templateVariables": "Template Variables",
@@ -563,6 +567,7 @@
   },
   "playground": {
     "missingPromptId": "Missing prompt ID.",
+    "model": "{{provider}} / {{model}}",
     "turnLimit": "Turn limit",
     "budget": "Budget ($)",
     "saveAsTestCase": "Save as Test Case",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -19,8 +19,10 @@
     "runNumber": "Ejecución #{{number}}"
   },
   "promptLayout": {
-    "vars": "{{count}} vars",
-    "anchors": "{{count}} anclas",
+    "vars_one": "{{count}} var",
+    "vars_other": "{{count}} vars",
+    "anchors_one": "{{count}} ancla",
+    "anchors_other": "{{count}} anclas",
     "missingId": "Falta el ID del prompt.",
     "notFound": "Prompt no encontrado.",
     "template": "Plantilla",
@@ -39,8 +41,10 @@
     "noPromptsDescription": "Registra tu primer prompt para comenzar a evolucionarlo.",
     "newPrompt": "Nuevo Prompt",
     "noMatch": "Ningún prompt coincide con tu búsqueda.",
-    "vars": "{{count}} vars",
-    "anchors": "{{count}} anclas",
+    "vars_one": "{{count}} var",
+    "vars_other": "{{count}} vars",
+    "anchors_one": "{{count}} ancla",
+    "anchors_other": "{{count}} anclas",
     "failedToLoadPrompt": "Error al cargar el prompt.",
     "promptNotFound": "Prompt no encontrado.",
     "templateVariables": "Variables de plantilla",
@@ -541,6 +545,7 @@
   },
   "playground": {
     "missingPromptId": "Falta el ID del prompt.",
+    "model": "{{provider}} / {{model}}",
     "turnLimit": "Límite de turnos",
     "budget": "Presupuesto ($)",
     "saveAsTestCase": "Guardar como caso de prueba",

--- a/frontend/src/locales/zh/common.json
+++ b/frontend/src/locales/zh/common.json
@@ -19,8 +19,10 @@
     "runNumber": "运行 #{{number}}"
   },
   "promptLayout": {
-    "vars": "{{count}} 个变量",
-    "anchors": "{{count}} 个锚点",
+    "vars_one": "{{count}} 个变量",
+    "vars_other": "{{count}} 个变量",
+    "anchors_one": "{{count}} 个锚点",
+    "anchors_other": "{{count}} 个锚点",
     "missingId": "缺少提示词 ID。",
     "notFound": "未找到提示词。",
     "template": "模板",
@@ -39,8 +41,10 @@
     "noPromptsDescription": "注册你的第一个提示词，开始进化之旅。",
     "newPrompt": "新建提示词",
     "noMatch": "没有匹配的提示词。",
-    "vars": "{{count}} 个变量",
-    "anchors": "{{count}} 个锚点",
+    "vars_one": "{{count}} 个变量",
+    "vars_other": "{{count}} 个变量",
+    "anchors_one": "{{count}} 个锚点",
+    "anchors_other": "{{count}} 个锚点",
     "failedToLoadPrompt": "加载提示词失败。",
     "promptNotFound": "未找到提示词。",
     "templateVariables": "模板变量",
@@ -541,6 +545,7 @@
   },
   "playground": {
     "missingPromptId": "缺少提示词 ID。",
+    "model": "{{provider}} / {{model}}",
     "turnLimit": "对话轮数限制",
     "budget": "预算（$）",
     "saveAsTestCase": "保存为测试用例",

--- a/frontend/src/pages/PromptPlaygroundPage.tsx
+++ b/frontend/src/pages/PromptPlaygroundPage.tsx
@@ -6,6 +6,7 @@ import { getPromptApiPromptsPromptIdGet, addCaseApiPromptsPromptIdDatasetPost } 
 import type { PromptDetail } from '@/client/types.gen'
 import { useChatStream } from '@/hooks/useChatStream'
 import type { ChatMessage } from '@/hooks/useChatStream'
+import { getApiBaseUrl } from '@/lib/api-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
@@ -70,6 +71,17 @@ export default function PromptPlaygroundPage() {
   })
 
   const detail = prompt?.data as PromptDetail | undefined
+
+  const { data: promptConfig } = useQuery({
+    queryKey: ['prompt-config', promptId],
+    queryFn: async () => {
+      const base = getApiBaseUrl()
+      const res = await fetch(`${base}/api/prompts/${encodeURIComponent(promptId!)}/config`)
+      if (!res.ok) return null
+      return res.json() as Promise<{ target: { provider: string; model: string } }>
+    },
+    enabled: !!promptId,
+  })
 
   const chat = useChatStream(promptId ?? '')
 
@@ -246,6 +258,15 @@ export default function PromptPlaygroundPage() {
       <div className="flex-shrink-0 space-y-3 mb-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
+            {/* Model indicator */}
+            {promptConfig?.target && (
+              <Badge variant="secondary" className="text-xs font-mono">
+                {t('playground.model', {
+                  provider: promptConfig.target.provider,
+                  model: promptConfig.target.model,
+                })}
+              </Badge>
+            )}
             {/* Turn limit */}
             <div className="flex items-center gap-1.5">
               <label className="text-xs text-muted-foreground whitespace-nowrap">{t('playground.turnLimit')}</label>


### PR DESCRIPTION
## Summary

- **Wizard**: Hide "Back" button on step 1 (nowhere to go back to)
- **Pluralization**: Fix "1 anchors" → "1 anchor", "1 vars" → "1 var" using i18next `_one`/`_other` forms across all 3 locales (en/es/zh) in both `promptLayout` and `prompts` namespaces
- **Playground**: Show model/provider badge (e.g. "gemini / gemini-2.5-flash") so users know which model they're chatting with. Uses cached config query.

## Test plan

- [x] `npm run test` — 200 passed, 0 failed
- [x] Wizard step 1: no Back button visible
- [x] Prompt header: "1 anchor" / "2 vars" correct pluralization
- [x] Playground: model badge visible near controls

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)