### PR TITLE
fix: resolve security vulnerabilities and flaky Boltzmann test

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -72,7 +72,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^28.1.0",
-        "monaco-editor": "^0.55.1",
+        "monaco-editor": "^0.53.0",
         "tailwindcss": "^4.2.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
@@ -3149,12 +3149,11 @@
       }
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
+      "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4599,16 +4598,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -5009,9 +4998,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5922,19 +5911,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -5981,14 +5957,13 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.53.0.tgz",
+      "integrity": "sha512-0WNThgC6CMWNXXBxTbaYYcunj08iB5rnx4/G56UOPeL9UVIUGGHA1GR0EWIh9Ebabj7NpCRawQ5b0hfN1jQmYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
+        "@types/trusted-types": "^1.0.6"
       }
     },
     "node_modules/ms": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^28.1.0",
-    "monaco-editor": "^0.55.1",
+    "monaco-editor": "^0.53.0",
     "tailwindcss": "^4.2.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",

--- a/tests/evolution/test_selector.py
+++ b/tests/evolution/test_selector.py
@@ -68,14 +68,20 @@ class TestBoltzmannSelectorEdgeCases:
         assert all(c.id == "only" for c in result)
 
     def test_rejected_candidates_included_in_selection(self, selector):
-        """Rejected candidates participate in selection (no filtering)."""
+        """Rejected candidates participate in selection (no filtering).
+
+        Uses a smaller score gap (-1.0 vs -2.0) and more samples (500) to
+        make the test deterministic — with the old gap (-1.0 vs -5.0) and
+        only 100 samples, the penalized candidate had ~1.8% per-draw
+        probability, causing intermittent failures.
+        """
         candidates = [
             Candidate(id="good", template="good", fitness_score=-1.0),
-            Candidate(id="penalized", template="penalized", fitness_score=-5.0, rejected=True),
+            Candidate(id="penalized", template="penalized", fitness_score=-2.0, rejected=True),
         ]
-        result = selector.select(candidates=candidates, n_parents=100, temperature=1.0)
-        assert len(result) == 100
-        # Both candidates should appear at least once in 100 selections
+        result = selector.select(candidates=candidates, n_parents=500, temperature=1.0)
+        assert len(result) == 500
+        # Both candidates should appear at least once in 500 selections
         selected_ids = {c.id for c in result}
         assert "good" in selected_ids
         assert "penalized" in selected_ids


### PR DESCRIPTION
## Summary

### Security (Issue #13)
- Update `flatted` 3.4.1 → 3.4.2 (high: Prototype Pollution via `parse()`)
- Downgrade `monaco-editor` 0.55.1 → 0.53.0 to resolve `dompurify` XSS vulnerability (monaco ≥0.54 bundles vulnerable dompurify 3.1.3-3.3.1)
- `npm audit` now reports **0 vulnerabilities**

### Flaky test (Issue #14)
- Fix `test_rejected_candidates_included_in_selection`: reduce score gap (4.0 → 1.0) and increase samples (100 → 500)
- Old parameters gave ~1.8% per-draw probability → intermittent failures
- New parameters give ~27% per-draw probability → virtually certain across 500 draws
- Verified stable across 5 consecutive runs

## Test plan

- [x] Backend: `pytest` — 1190 passed, 0 failed
- [x] Frontend: `npm run test` — 203 passed, 0 failed
- [x] `npm audit` — 0 vulnerabilities
- [x] Flaky test: 5/5 consecutive passes

Closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)