### PR TITLE
fix: run detail polish — history list, header, 3D fallback, stop reason

### DIFF
--- a/frontend/src/components/evolution/EvolutionDashboard.tsx
+++ b/frontend/src/components/evolution/EvolutionDashboard.tsx
@@ -312,9 +312,6 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
       {/* Status bar with model badges */}
       <div className="flex items-center gap-4 text-sm flex-wrap">
         <StatusBadge status={displayStatus} />
-        <span className="text-muted-foreground">
-          Run: <span className="font-mono text-foreground">{runId}</span>
-        </span>
         {(modelInfo.metaModel || modelInfo.targetModel || modelInfo.judgeModel) && (
           <div className="flex flex-wrap gap-2 ml-auto">
             {modelInfo.metaModel && (

--- a/frontend/src/components/evolution/Islands3D.tsx
+++ b/frontend/src/components/evolution/Islands3D.tsx
@@ -1,4 +1,6 @@
-import { useRef, useState, useEffect, useMemo, useCallback } from 'react'
+import { useRef, useState, useEffect, useMemo, useCallback, Component } from 'react'
+import type { ReactNode, ErrorInfo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, Html } from '@react-three/drei'
 import * as THREE from 'three'
@@ -15,6 +17,42 @@ function isWebGLAvailable(): boolean {
     return !!(canvas.getContext('webgl2') || canvas.getContext('webgl'))
   } catch {
     return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error boundary for 3D render failures
+// ---------------------------------------------------------------------------
+interface CanvasErrorBoundaryState { hasError: boolean }
+
+function CanvasRenderErrorFallback() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center justify-center h-[500px] bg-slate-800 border border-slate-700 rounded-lg">
+      <p className="text-slate-400">{t('evolution.webglRequired')}</p>
+    </div>
+  )
+}
+
+class CanvasErrorBoundary extends Component<{ children: ReactNode }, CanvasErrorBoundaryState> {
+  constructor(props: { children: ReactNode }) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(_: Error): CanvasErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(_error: Error, _info: ErrorInfo) {
+    // Render failure is surfaced via the fallback UI
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <CanvasRenderErrorFallback />
+    }
+    return this.props.children
   }
 }
 
@@ -595,6 +633,7 @@ function Islands3DScene({
   islandCount,
   lineageEvents,
 }: Omit<Islands3DProps, 'seedFitness'>) {
+  const { t } = useTranslation()
   const containerRef = useRef<HTMLDivElement>(null)
   const islandLayouts = useMemo(() => computeIslandLayout(islandCount), [islandCount])
   const [containerDims, setContainerDims] = useState({ width: 800, height: 500 })
@@ -702,8 +741,15 @@ function Islands3DScene({
     }
   }, [candidateCountPerIsland]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  const isEmpty = candidates.length === 0 && islandCount === 0
+
   return (
     <div ref={containerRef} className="bg-slate-800 border border-slate-700 rounded-lg p-4 h-[500px] relative">
+      {isEmpty && (
+        <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
+          <p className="text-slate-400">{t('evolution.noIslandDataToDisplay')}</p>
+        </div>
+      )}
       <Canvas camera={{ position: [0, 0, 15], fov: 50 }}>
         {/* Three-point lighting: ambient fill + directional key + point fill + cool rim */}
         <ambientLight intensity={0.3} />
@@ -797,11 +843,13 @@ export default function Islands3D({
   }
 
   return (
-    <Islands3DScene
-      candidates={candidates}
-      migrations={migrations}
-      islandCount={islandCount}
-      lineageEvents={lineageEvents}
-    />
+    <CanvasErrorBoundary>
+      <Islands3DScene
+        candidates={candidates}
+        migrations={migrations}
+        islandCount={islandCount}
+        lineageEvents={lineageEvents}
+      />
+    </CanvasErrorBoundary>
   )
 }

--- a/frontend/src/components/evolution/SummaryCards.tsx
+++ b/frontend/src/components/evolution/SummaryCards.tsx
@@ -89,6 +89,7 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
     <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
       {cards.map((card) => {
         const Icon = card.icon
+        const isLongValue = card.value.length > 14
         return (
           <Card key={card.label} className={`border-l-[3px] ${card.borderClass}`}>
             <CardContent className="pt-5 pb-5">
@@ -96,7 +97,7 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
                 <Icon className="h-3.5 w-3.5" />
                 {card.label}
               </div>
-              <p className={`text-2xl font-bold mt-1 ${card.colorClass}`}>
+              <p className={`${isLongValue ? 'text-lg' : 'text-2xl'} font-bold mt-1 ${card.colorClass} break-words`}>
                 {card.value}
               </p>
             </CardContent>

--- a/frontend/src/components/history/RunHistoryTable.tsx
+++ b/frontend/src/components/history/RunHistoryTable.tsx
@@ -41,14 +41,31 @@ function StatusBadge({ status }: { status: string }) {
   }
 }
 
-function HistoryTableSkeleton() {
+function relativeTime(date: Date): string {
+  const now = Date.now()
+  const diffMs = now - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  if (diffSec < 60) return `${diffSec}s ago`
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDay = Math.floor(diffHr / 24)
+  if (diffDay < 30) return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`
+  const diffMonth = Math.floor(diffDay / 30)
+  if (diffMonth < 12) return `${diffMonth} month${diffMonth === 1 ? '' : 's'} ago`
+  const diffYear = Math.floor(diffMonth / 12)
+  return `${diffYear} year${diffYear === 1 ? '' : 's'} ago`
+}
+
+function HistoryTableSkeleton({ withPromptColumn }: { withPromptColumn: boolean }) {
   const { t } = useTranslation()
   return (
     <Table>
       <TableHeader>
         <TableRow>
           <TableHead>{t('history.id')}</TableHead>
-          <TableHead>{t('history.prompt')}</TableHead>
+          {withPromptColumn && <TableHead>{t('history.prompt')}</TableHead>}
           <TableHead>{t('history.date')}</TableHead>
           <TableHead>{t('history.status')}</TableHead>
           <TableHead>{t('history.bestFitness')}</TableHead>
@@ -61,7 +78,7 @@ function HistoryTableSkeleton() {
         {[1, 2, 3].map((i) => (
           <TableRow key={i}>
             <TableCell><Skeleton className="h-4 w-[80px]" /></TableCell>
-            <TableCell><Skeleton className="h-4 w-[100px]" /></TableCell>
+            {withPromptColumn && <TableCell><Skeleton className="h-4 w-[100px]" /></TableCell>}
             <TableCell><Skeleton className="h-4 w-[140px]" /></TableCell>
             <TableCell><Skeleton className="h-5 w-[70px] rounded-full" /></TableCell>
             <TableCell><Skeleton className="h-4 w-[60px]" /></TableCell>
@@ -176,7 +193,7 @@ export default function RunHistoryTable({ promptId: propPromptId }: RunHistoryTa
       )}
 
       {selectedPromptId && historyLoading && (
-        <HistoryTableSkeleton />
+        <HistoryTableSkeleton withPromptColumn={!propPromptId} />
       )}
 
       {selectedPromptId && !historyLoading && sortedRuns.length === 0 && (
@@ -197,7 +214,7 @@ export default function RunHistoryTable({ promptId: propPromptId }: RunHistoryTa
             <TableHeader>
               <TableRow>
                 <TableHead>{t('history.id')}</TableHead>
-                <TableHead>{t('history.prompt')}</TableHead>
+                {!propPromptId && <TableHead>{t('history.prompt')}</TableHead>}
                 <TableHead>{t('history.date')}</TableHead>
                 <TableHead>{t('history.status')}</TableHead>
                 <TableHead>{t('history.bestFitness')}</TableHead>
@@ -207,32 +224,36 @@ export default function RunHistoryTable({ promptId: propPromptId }: RunHistoryTa
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sortedRuns.map((run) => (
-                <TableRow
-                  key={run.id}
-                  onClick={() => navigate(propPromptId ? `${run.id}` : `/history/${run.id}`)}
-                  className="cursor-pointer"
-                >
-                  <TableCell className="font-mono text-xs">{run.id}</TableCell>
-                  <TableCell>{run.prompt_id}</TableCell>
-                  <TableCell className="whitespace-nowrap">
-                    {new Date(run.created_at).toLocaleString()}
-                  </TableCell>
-                  <TableCell>
-                    <StatusBadge status={run.status} />
-                  </TableCell>
-                  <TableCell className="font-mono">
-                    {run.best_fitness_score !== null ? run.best_fitness_score.toFixed(3) : '--'}
-                  </TableCell>
-                  <TableCell className="font-mono">
-                    ${run.total_cost_usd.toFixed(2)}
-                  </TableCell>
-                  <TableCell className="text-center">{run.generations_completed}</TableCell>
-                  <TableCell className="text-xs text-muted-foreground">
-                    {run.meta_model} / {run.target_model}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {sortedRuns.map((run) => {
+                const createdDate = new Date(run.created_at)
+                return (
+                  <TableRow
+                    key={run.id}
+                    onClick={() => navigate(propPromptId ? `${run.id}` : `/history/${run.id}`)}
+                    className="cursor-pointer hover:bg-muted/50 transition-colors"
+                  >
+                    <TableCell className="font-mono text-xs">{run.id}</TableCell>
+                    {!propPromptId && <TableCell>{run.prompt_id}</TableCell>}
+                    <TableCell className="whitespace-nowrap">
+                      <span>{createdDate.toLocaleString()}</span>
+                      <span className="ml-2 text-xs text-muted-foreground">· {relativeTime(createdDate)}</span>
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={run.status} />
+                    </TableCell>
+                    <TableCell className="font-mono">
+                      {run.best_fitness_score !== null ? run.best_fitness_score.toFixed(3) : '--'}
+                    </TableCell>
+                    <TableCell className="font-mono">
+                      ${run.total_cost_usd.toFixed(2)}
+                    </TableCell>
+                    <TableCell className="text-center">{run.generations_completed}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {run.meta_model} / {run.target_model}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
             </TableBody>
           </Table>
         </div>

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -304,6 +304,8 @@
     "toIsland": "Island {{to}}",
     "noDiffData": "No diff data available",
     "noIslandData": "No island data",
+    "noIslandDataToDisplay": "No island data to display",
+    "webglRequired": "3D visualization requires WebGL",
     "island": "Island {{index}}",
     "moreOverflow": "+{{count}} more",
     "migrationInProgress": "Migration in progress",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -281,6 +281,8 @@
     "toIsland": "Isla {{to}}",
     "noDiffData": "Sin datos de diferencias",
     "noIslandData": "Sin datos de islas",
+    "noIslandDataToDisplay": "No hay datos de islas para mostrar",
+    "webglRequired": "La visualización 3D requiere WebGL",
     "island": "Isla {{index}}",
     "moreOverflow": "+{{count}} más",
     "migrationInProgress": "Migración en progreso",

--- a/frontend/src/locales/zh/common.json
+++ b/frontend/src/locales/zh/common.json
@@ -281,6 +281,8 @@
     "toIsland": "岛屿 {{to}}",
     "noDiffData": "无差异数据",
     "noIslandData": "无岛屿数据",
+    "noIslandDataToDisplay": "无岛屿数据可显示",
+    "webglRequired": "3D可视化需要WebGL支持",
     "island": "岛屿 {{index}}",
     "moreOverflow": "+{{count}} 更多",
     "migrationInProgress": "迁移进行中",


### PR DESCRIPTION
## Summary

- **History list**: remove redundant Prompt column (already in page context), add hover cursor/highlight on rows, add relative time ("2 days ago")
- **Run header**: remove redundant "Run: 1" text (heading already says "Run #1")
- **3D Islands**: add error boundary with "WebGL required" fallback, show "No island data" overlay when canvas is empty
- **Stop Reason card**: use `text-lg` instead of `text-2xl` for long values to prevent 3-line wrap

## Test plan

- [x] `npm run test` — 203 passed, 0 failed
- [x] History list: rows show hover state, no Prompt column, relative time visible
- [x] Run header: clean, no duplicate run number
- [x] 3D Islands: shows fallback message when no data
- [x] Stop Reason card: text fits properly

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)