### PR TITLE
fix: remove unused import breaking Docker build

### DIFF
--- a/frontend/src/components/evolution/ThinkingBudgetControl.tsx
+++ b/frontend/src/components/evolution/ThinkingBudgetControl.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from 'react-i18next'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
 
 interface ThinkingBudgetControlProps {
@@ -53,7 +52,6 @@ export default function ThinkingBudgetControl({
   onLevelChange,
 }: ThinkingBudgetControlProps) {
   // Only show for Gemini provider with a selected model
-  const { t } = useTranslation()
   if (provider !== 'gemini' || !modelId) return null
 
   if (isGemini25(modelId)) {


### PR DESCRIPTION
## Summary
- Removed unused `useTranslation` import and `t` variable from `ThinkingBudgetControl.tsx`
- This caused a `TS6133` error during `tsc -b` in the Docker production build stage

## Test plan
- [x] Run `docker compose build --no-cache` and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)