### PR TITLE
fix: frontend audit — accessibility, theming, responsive

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ErrorBoundary } from './components/layout/ErrorBoundary'
 import AppShell from './components/layout/AppShell'
 import { PromptLayout } from './components/layout/PromptLayout'
 import PromptsPage from './pages/PromptsPage'
@@ -19,6 +20,7 @@ const queryClient = new QueryClient()
 
 export default function App() {
   return (
+    <ErrorBoundary>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <Routes>
@@ -46,5 +48,6 @@ export default function App() {
         </Routes>
       </BrowserRouter>
     </QueryClientProvider>
+    </ErrorBoundary>
   )
 }

--- a/frontend/src/__tests__/case-results.test.tsx
+++ b/frontend/src/__tests__/case-results.test.tsx
@@ -50,7 +50,7 @@ describe('CaseResultsGrid', () => {
     const lowBadge = screen.getByText('low')
     expect(criticalBadge.className).toContain('text-red')
     expect(normalBadge.className).toContain('text-blue')
-    expect(lowBadge.className).toContain('text-slate')
+    expect(lowBadge.className).toContain('text-muted-foreground')
   })
 
   it('expands a row when clicked to show expected vs actual', () => {

--- a/frontend/src/__tests__/layout.test.tsx
+++ b/frontend/src/__tests__/layout.test.tsx
@@ -29,7 +29,8 @@ describe('AppShell', () => {
       </Routes>
     )
 
-    expect(screen.getByText('Prompts')).toBeInTheDocument()
+    // Both mobile and desktop sidebars render nav items
+    expect(screen.getAllByText('Prompts').length).toBeGreaterThanOrEqual(1)
   })
 
   it('Prompts nav link points to /prompts', () => {
@@ -41,7 +42,8 @@ describe('AppShell', () => {
       </Routes>
     )
 
-    expect(screen.getByText('Prompts').closest('a')).toHaveAttribute('href', '/prompts')
+    const promptLinks = screen.getAllByText('Prompts')
+    expect(promptLinks[0].closest('a')).toHaveAttribute('href', '/prompts')
   })
 
   it('renders outlet for child content at /prompts', () => {
@@ -66,6 +68,7 @@ describe('AppShell', () => {
       </Routes>
     )
 
-    expect(screen.getByText('Helix')).toBeInTheDocument()
+    // Both mobile and desktop sidebars render the app name
+    expect(screen.getAllByText('Helix').length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/frontend/src/components/datasets/CaseEditor.tsx
+++ b/frontend/src/components/datasets/CaseEditor.tsx
@@ -150,7 +150,7 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[600px] sm:max-w-[600px] overflow-y-auto">
+      <SheetContent side="right" className="w-full sm:w-[600px] sm:max-w-[600px] overflow-y-auto">
         <SheetHeader>
           <SheetTitle>{isEdit ? t('datasets.editTestCase') : t('datasets.addTestCaseTitle')}</SheetTitle>
           <SheetDescription>
@@ -161,8 +161,9 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
         <div className="space-y-4 mt-6">
           {/* Name */}
           <div>
-            <label className="block text-sm text-muted-foreground mb-1">{t('datasets.name')}</label>
+            <label htmlFor="case-name" className="block text-sm text-muted-foreground mb-1">{t('datasets.name')}</label>
             <Input
+              id="case-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={t('datasets.testCaseName')}
@@ -171,8 +172,9 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
 
           {/* Description */}
           <div>
-            <label className="block text-sm text-muted-foreground mb-1">{t('datasets.description')}</label>
+            <label htmlFor="case-description" className="block text-sm text-muted-foreground mb-1">{t('datasets.description')}</label>
             <Textarea
+              id="case-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={2}
@@ -183,9 +185,9 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
           {/* Tier + Tags row */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm text-muted-foreground mb-1">{t('datasets.tier')}</label>
+              <label htmlFor="case-tier" className="block text-sm text-muted-foreground mb-1">{t('datasets.tier')}</label>
               <Select value={tier} onValueChange={setTier}>
-                <SelectTrigger>
+                <SelectTrigger id="case-tier">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -196,8 +198,9 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
               </Select>
             </div>
             <div>
-              <label className="block text-sm text-muted-foreground mb-1">{t('datasets.tagsCommaSeparated')}</label>
+              <label htmlFor="case-tags" className="block text-sm text-muted-foreground mb-1">{t('datasets.tagsCommaSeparated')}</label>
               <Input
+                id="case-tags"
                 value={tags}
                 onChange={(e) => setTags(e.target.value)}
                 placeholder="tag1, tag2"
@@ -207,8 +210,9 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
 
           {/* Variables JSON */}
           <div>
-            <label className="block text-sm text-muted-foreground mb-1">{t('datasets.variablesJson')}</label>
+            <label htmlFor="case-variables" className="block text-sm text-muted-foreground mb-1">{t('datasets.variablesJson')}</label>
             <Textarea
+              id="case-variables"
               value={variables}
               onChange={(e) => setVariables(e.target.value)}
               rows={3}
@@ -219,10 +223,11 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
 
           {/* Behavior Criteria */}
           <div>
-            <label className="block text-sm text-muted-foreground mb-1">
+            <label htmlFor="case-behavior" className="block text-sm text-muted-foreground mb-1">
               {t('datasets.behaviorCriteria')}
             </label>
             <Textarea
+              id="case-behavior"
               value={behaviorCriteria}
               onChange={(e) => setBehaviorCriteria(e.target.value)}
               rows={3}
@@ -232,8 +237,9 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
 
           {/* Expected Output JSON */}
           <div>
-            <label className="block text-sm text-muted-foreground mb-1">{t('datasets.expectedOutputJson')}</label>
+            <label htmlFor="case-expected-output" className="block text-sm text-muted-foreground mb-1">{t('datasets.expectedOutputJson')}</label>
             <Textarea
+              id="case-expected-output"
               value={expectedOutput}
               onChange={(e) => setExpectedOutput(e.target.value)}
               rows={3}
@@ -247,18 +253,19 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
             <CardContent className="pt-4 space-y-3">
               <p className="text-sm font-medium text-foreground">{t('datasets.scorerFlags')}</p>
               <div className="flex items-center justify-between">
-                <label className="text-sm text-muted-foreground">
+                <label htmlFor="case-require-content" className="text-sm text-muted-foreground">
                   {t('datasets.requireContent')}
                 </label>
                 <Switch
+                  id="case-require-content"
                   checked={requireContent}
                   onCheckedChange={setRequireContent}
                 />
               </div>
               <div className="flex items-center justify-between">
-                <label className="text-sm text-muted-foreground">{t('datasets.argumentMatchingMode')}</label>
+                <label htmlFor="case-match-args" className="text-sm text-muted-foreground">{t('datasets.argumentMatchingMode')}</label>
                 <Select value={matchArgs} onValueChange={setMatchArgs}>
-                  <SelectTrigger className="w-[120px]">
+                  <SelectTrigger id="case-match-args" className="w-[120px]">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -272,8 +279,9 @@ export function CaseEditor({ promptId, existingCase, open, onOpenChange }: CaseE
 
           {/* Chat History JSON */}
           <div>
-            <label className="block text-sm text-muted-foreground mb-1">{t('datasets.chatHistoryJson')}</label>
+            <label htmlFor="case-chat-history" className="block text-sm text-muted-foreground mb-1">{t('datasets.chatHistoryJson')}</label>
             <Textarea
+              id="case-chat-history"
               value={chatHistory}
               onChange={(e) => setChatHistory(e.target.value)}
               rows={3}

--- a/frontend/src/components/evolution/CaseResultsGrid.tsx
+++ b/frontend/src/components/evolution/CaseResultsGrid.tsx
@@ -12,7 +12,7 @@ interface CaseResultsGridProps {
 const TIER_STYLES: Record<string, string> = {
   critical: 'bg-red-500/20 text-red-400',
   normal: 'bg-blue-500/20 text-blue-400',
-  low: 'bg-slate-500/20 text-slate-400',
+  low: 'bg-muted text-muted-foreground',
 }
 
 const TIER_PRIORITY: Record<string, number> = {
@@ -35,6 +35,8 @@ function PassIcon({ caseId }: { caseId: string }) {
       viewBox="0 0 24 24"
       strokeWidth={2}
       stroke="currentColor"
+      role="img"
+      aria-label="Passed"
     >
       <path
         strokeLinecap="round"
@@ -54,6 +56,8 @@ function FailIcon({ caseId }: { caseId: string }) {
       viewBox="0 0 24 24"
       strokeWidth={2}
       stroke="currentColor"
+      role="img"
+      aria-label="Failed"
     >
       <path
         strokeLinecap="round"
@@ -76,10 +80,10 @@ function DetailPanel({
     <div className="grid gap-4 p-4 md:grid-cols-2">
       {/* Expected */}
       <div>
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           {t('evolution.expected')}
         </p>
-        <pre className="max-h-48 overflow-auto rounded bg-slate-900/60 p-3 text-xs text-slate-300">
+        <pre className="max-h-48 overflow-auto rounded bg-muted p-3 text-xs text-foreground">
           {caseResult.expected
             ? JSON.stringify(caseResult.expected, null, 2)
             : '(none)'}
@@ -88,23 +92,23 @@ function DetailPanel({
 
       {/* Actual */}
       <div>
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           {t('evolution.actual')}
         </p>
         {caseResult.actualContent && (
-          <pre className="mb-2 max-h-48 overflow-auto rounded bg-slate-900/60 p-3 text-xs text-slate-300">
+          <pre className="mb-2 max-h-48 overflow-auto rounded bg-muted p-3 text-xs text-foreground">
             {caseResult.actualContent}
           </pre>
         )}
         {caseResult.actualToolCalls && caseResult.actualToolCalls.length > 0 && (
-          <pre className="max-h-48 overflow-auto rounded bg-slate-900/60 p-3 text-xs text-slate-300">
+          <pre className="max-h-48 overflow-auto rounded bg-muted p-3 text-xs text-foreground">
             {JSON.stringify(caseResult.actualToolCalls, null, 2)}
           </pre>
         )}
         {!caseResult.actualContent &&
           (!caseResult.actualToolCalls ||
             caseResult.actualToolCalls.length === 0) && (
-            <p className="text-xs text-slate-500">{t('evolution.noActualOutput')}</p>
+            <p className="text-xs text-muted-foreground">{t('evolution.noActualOutput')}</p>
           )}
       </div>
 
@@ -121,7 +125,7 @@ function DetailPanel({
                 Improved ({(caseResult.score - seedResult.score).toFixed(1)})
               </span>
             ) : caseResult.score === seedResult.score ? (
-              <span className="rounded-full bg-slate-500/20 px-2 py-0.5 text-xs font-semibold text-slate-400">
+              <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground">
                 No change
               </span>
             ) : (
@@ -132,8 +136,8 @@ function DetailPanel({
           </div>
           <div className="grid gap-3 md:grid-cols-2">
             {/* Seed column */}
-            <div className="rounded border border-slate-700/50 bg-slate-900/40 p-2">
-              <p className="mb-1 text-xs font-semibold text-slate-500">{t('evolution.seedOriginalPrompt')}</p>
+            <div className="rounded border border-border/50 bg-muted p-2">
+              <p className="mb-1 text-xs font-semibold text-muted-foreground">{t('evolution.seedOriginalPrompt')}</p>
               <div className="flex items-center gap-2">
                 <span className={`text-xs font-semibold ${seedResult.passed ? 'text-emerald-400' : 'text-red-400'}`}>
                   {seedResult.passed ? 'PASS' : 'FAIL'}
@@ -142,11 +146,11 @@ function DetailPanel({
                   {seedResult.score.toFixed(3)}
                 </span>
               </div>
-              <p className="mt-1 text-xs text-slate-400">{seedResult.reason}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{seedResult.reason}</p>
             </div>
             {/* Evolved column */}
-            <div className="rounded border border-slate-700/50 bg-slate-900/40 p-2">
-              <p className="mb-1 text-xs font-semibold text-slate-500">{t('evolution.evolvedBestCandidate')}</p>
+            <div className="rounded border border-border/50 bg-muted p-2">
+              <p className="mb-1 text-xs font-semibold text-muted-foreground">{t('evolution.evolvedBestCandidate')}</p>
               <div className="flex items-center gap-2">
                 <span className={`text-xs font-semibold ${caseResult.passed ? 'text-emerald-400' : 'text-red-400'}`}>
                   {caseResult.passed ? 'PASS' : 'FAIL'}
@@ -155,7 +159,7 @@ function DetailPanel({
                   {caseResult.score.toFixed(3)}
                 </span>
               </div>
-              <p className="mt-1 text-xs text-slate-400">{caseResult.reason}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{caseResult.reason}</p>
             </div>
           </div>
         </div>
@@ -164,7 +168,7 @@ function DetailPanel({
       {/* Behavior Criteria Breakdown */}
       {caseResult.criteriaResults && caseResult.criteriaResults.length > 0 && (
         <div className="md:col-span-2">
-          <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             {t('datasets.personaBehaviorCriteria')}
           </p>
           <div className="space-y-1">
@@ -173,8 +177,8 @@ function DetailPanel({
                 <span className={cr.passed ? 'text-emerald-400' : 'text-red-400'}>
                   {cr.passed ? '\u2713' : '\u2717'}
                 </span>
-                <span className="text-slate-300 font-medium">{cr.criterion}:</span>
-                <span className="text-slate-400">{cr.reason}</span>
+                <span className="text-foreground font-medium">{cr.criterion}:</span>
+                <span className="text-muted-foreground">{cr.reason}</span>
               </div>
             ))}
           </div>
@@ -233,7 +237,7 @@ export default function CaseResultsGrid({
 
   if (caseResults.length === 0) {
     return (
-      <div className="rounded-lg border border-slate-700 bg-slate-800/50 p-8 text-center text-slate-400">
+      <div className="rounded-lg border border-border bg-card/50 p-8 text-center text-muted-foreground">
         {t('evolution.noCaseResults')}
       </div>
     )
@@ -242,15 +246,15 @@ export default function CaseResultsGrid({
   return (
     <div className="space-y-4">
       {/* Summary stats bar */}
-      <div className="rounded-lg border border-slate-700 bg-slate-800 p-4">
+      <div className="rounded-lg border border-border bg-card p-4">
         <div className="mb-2 flex items-center gap-4 text-sm">
-          <span className="text-slate-400">
+          <span className="text-muted-foreground">
             {t('evolution.totalCases', { count: caseResults.length })}
           </span>
           <span className="text-emerald-400">{t('evolution.passedCount', { count: passedCount })}</span>
           <span className="text-red-400">{t('evolution.failedCount', { count: failedCount })}</span>
         </div>
-        <div className="flex h-2 overflow-hidden rounded-full bg-slate-700">
+        <div className="flex h-2 overflow-hidden rounded-full bg-border">
           <div
             className="bg-emerald-500 transition-all"
             style={{ width: `${passRate}%` }}
@@ -263,23 +267,23 @@ export default function CaseResultsGrid({
       </div>
 
       {/* Table */}
-      <div className="overflow-hidden rounded-lg border border-slate-700 bg-slate-800">
+      <div className="overflow-hidden rounded-lg border border-border bg-card">
         <table className="w-full">
           <thead>
-            <tr className="bg-slate-700/50">
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-400">
+            <tr className="bg-muted">
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 {t('evolution.caseId')}
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-400">
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 {t('datasets.tier')}
               </th>
-              <th className="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-slate-400">
+              <th className="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 {t('evolution.result')}
               </th>
-              <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-slate-400">
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 {t('evolution.fitness')}
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-400">
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 {t('evolution.reason')}
               </th>
             </tr>
@@ -292,12 +296,21 @@ export default function CaseResultsGrid({
               return (
                 <Fragment key={c.caseId}>
                   <tr
+                    tabIndex={0}
+                    role="button"
+                    aria-expanded={isExpanded}
                     onClick={() => toggleExpand(c.caseId)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        toggleExpand(c.caseId)
+                      }
+                    }}
                     className={`cursor-pointer ${
-                      idx % 2 === 0 ? 'bg-slate-800/50' : 'bg-slate-900/30'
-                    } hover:bg-slate-700/30`}
+                      idx % 2 === 0 ? 'bg-card/50' : 'bg-background/30'
+                    } hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background`}
                   >
-                    <td className="px-4 py-3 text-sm text-slate-300" title={c.caseId}>
+                    <td className="px-4 py-3 text-sm text-foreground" title={c.caseId}>
                       {caseNames?.get(c.caseId) ?? c.caseId}
                     </td>
                     <td className="px-4 py-3">
@@ -320,7 +333,7 @@ export default function CaseResultsGrid({
                     >
                       {c.score.toFixed(3)}
                     </td>
-                    <td className="px-4 py-3 text-sm text-slate-400" title={c.reason}>
+                    <td className="px-4 py-3 text-sm text-muted-foreground" title={c.reason}>
                       <span className={`mr-1 font-semibold ${c.passed ? 'text-emerald-400' : 'text-red-400'}`}>
                         {c.passed ? '[PASS]' : '[FAIL]'}
                       </span>
@@ -331,7 +344,7 @@ export default function CaseResultsGrid({
                     <tr>
                       <td
                         colSpan={5}
-                        className="border-t border-slate-700/50 bg-slate-900/40"
+                        className="border-t border-border/50 bg-muted"
                       >
                         <DetailPanel
                           caseResult={c}

--- a/frontend/src/components/evolution/DiffPopover.tsx
+++ b/frontend/src/components/evolution/DiffPopover.tsx
@@ -30,7 +30,7 @@ function DiffLineRow({ line }: { line: DiffLine }) {
       </div>
     )
   }
-  return <div className="text-slate-500"> {line.content}</div>
+  return <div className="text-muted-foreground"> {line.content}</div>
 }
 
 export function DiffPopover({
@@ -64,10 +64,10 @@ export function DiffPopover({
   if (!candidate || candidate.template === undefined) {
     return (
       <div
-        className="absolute pointer-events-none w-[400px] h-[300px] bg-slate-900 border border-slate-600 rounded-lg shadow-xl z-30 flex items-center justify-center"
+        className="absolute pointer-events-none w-[400px] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex items-center justify-center"
         style={{ left: `${left}px`, top: `${top}px` }}
       >
-        <p className="text-slate-400 text-sm">{t('evolution.noTemplateData')}</p>
+        <p className="text-muted-foreground text-sm">{t('evolution.noTemplateData')}</p>
       </div>
     )
   }
@@ -76,11 +76,11 @@ export function DiffPopover({
   if (diffResult?.type === 'seed') {
     return (
       <div
-        className="absolute pointer-events-none w-[400px] h-[300px] bg-slate-900 border border-slate-600 rounded-lg shadow-xl z-30 flex flex-col overflow-hidden"
+        className="absolute pointer-events-none w-[400px] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex flex-col overflow-hidden"
         style={{ left: `${left}px`, top: `${top}px` }}
       >
-        <div className="flex items-center gap-2 px-3 py-2 bg-slate-700/50 border-b border-slate-600 shrink-0">
-          <span className="font-mono text-slate-200 text-xs font-bold">
+        <div className="flex items-center gap-2 px-3 py-2 bg-muted border-b border-border shrink-0">
+          <span className="font-mono text-foreground text-xs font-bold">
             {candidate.candidateId}
           </span>
           <span
@@ -98,7 +98,7 @@ export function DiffPopover({
           </span>
         </div>
         <div className="overflow-y-auto max-h-[260px] px-3 py-2">
-          <pre className="font-mono text-xs leading-relaxed text-slate-300 whitespace-pre-wrap">
+          <pre className="font-mono text-xs leading-relaxed text-foreground whitespace-pre-wrap">
             {candidate.template}
           </pre>
         </div>
@@ -110,10 +110,10 @@ export function DiffPopover({
   if (diffResult?.type === 'no-parent' || diffResult?.type === 'no-parent-template') {
     return (
       <div
-        className="absolute pointer-events-none w-[400px] h-[300px] bg-slate-900 border border-slate-600 rounded-lg shadow-xl z-30 flex items-center justify-center"
+        className="absolute pointer-events-none w-[400px] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex items-center justify-center"
         style={{ left: `${left}px`, top: `${top}px` }}
       >
-        <p className="text-slate-400 text-sm">{t('evolution.parentTemplateNotAvailable')}</p>
+        <p className="text-muted-foreground text-sm">{t('evolution.parentTemplateNotAvailable')}</p>
       </div>
     )
   }
@@ -126,12 +126,12 @@ export function DiffPopover({
 
     return (
       <div
-        className="absolute pointer-events-none w-[400px] h-[300px] bg-slate-900 border border-slate-600 rounded-lg shadow-xl z-30 flex flex-col overflow-hidden"
+        className="absolute pointer-events-none w-[400px] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex flex-col overflow-hidden"
         style={{ left: `${left}px`, top: `${top}px` }}
       >
         {/* Header */}
-        <div className="flex items-center gap-2 px-3 py-2 bg-slate-700/50 border-b border-slate-600 shrink-0">
-          <span className="font-mono text-slate-200 text-xs font-bold">
+        <div className="flex items-center gap-2 px-3 py-2 bg-muted border-b border-border shrink-0">
+          <span className="font-mono text-foreground text-xs font-bold">
             {candidate.candidateId.slice(0, 8)}
           </span>
           <span
@@ -148,7 +148,7 @@ export function DiffPopover({
             {candidate.fitnessScore.toFixed(3)}
           </span>
           {(addCount > 0 || delCount > 0) && (
-            <span className="text-xs text-slate-400 ml-auto font-mono">
+            <span className="text-xs text-muted-foreground ml-auto font-mono">
               +{addCount} -{delCount}
             </span>
           )}

--- a/frontend/src/components/evolution/DiffViewer.tsx
+++ b/frontend/src/components/evolution/DiffViewer.tsx
@@ -121,7 +121,7 @@ export default function DiffViewer({
 
   if (nodesWithTemplates.length < 2) {
     return (
-      <div className="rounded-lg border border-slate-700 bg-slate-800/50 p-8 text-center">
+      <div className="rounded-lg border border-border bg-card/50 p-8 text-center">
         <p style={{ color: COLORS.textMuted }}>{t('evolution.noDiffData')}</p>
       </div>
     )
@@ -131,10 +131,10 @@ export default function DiffViewer({
     <div className="space-y-4">
       {/* Seed / Initial Template */}
       {seedNode && (
-        <div className="bg-slate-800 border border-slate-700 rounded-lg overflow-hidden">
-          <div className="flex items-center gap-3 px-4 py-3 bg-slate-700/50">
-            <span className="font-bold text-white">{t('evolution.initialTemplate')}</span>
-            <span className="font-mono text-slate-400 text-sm">
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center gap-3 px-4 py-3 bg-muted">
+            <span className="font-bold text-foreground">{t('evolution.initialTemplate')}</span>
+            <span className="font-mono text-muted-foreground text-sm">
               {seedNode.candidateId.slice(0, 8)}
             </span>
             <span
@@ -155,14 +155,14 @@ export default function DiffViewer({
           <div className="px-4 py-3">
             <button
               onClick={() => setSeedExpanded(!seedExpanded)}
-              className="text-xs text-slate-400 hover:text-slate-200 mb-2"
+              className="text-xs text-muted-foreground hover:text-foreground mb-2"
             >
               {seedExpanded || defaultSeedExpanded
                 ? 'Collapse'
                 : `Expand (${seedLineCount} lines)`}
             </button>
             {(seedExpanded || defaultSeedExpanded) && (
-              <pre className="font-mono text-xs leading-relaxed text-slate-400 overflow-x-auto whitespace-pre-wrap">
+              <pre className="font-mono text-xs leading-relaxed text-muted-foreground overflow-x-auto whitespace-pre-wrap">
                 {seedTemplate}
               </pre>
             )}
@@ -178,17 +178,17 @@ export default function DiffViewer({
             {transitionMap.has(step.childId) && (
               <div className="flex items-center gap-2 px-4 py-2 text-xs text-purple-400 bg-purple-500/10 rounded-lg border border-purple-500/20">
                 <span>Migrated from Island {transitionMap.get(step.childId)!.fromIsland}</span>
-                <span className="text-slate-500">&rarr;</span>
+                <span className="text-muted-foreground">&rarr;</span>
                 <span>Island {transitionMap.get(step.childId)!.toIsland}</span>
               </div>
             )}
           <div
-            className="bg-slate-800 border border-slate-700 rounded-lg overflow-hidden"
+            className="bg-card border border-border rounded-lg overflow-hidden"
           >
             {/* Step header */}
-            <div className="flex items-center gap-3 px-4 py-3 bg-slate-700/50 flex-wrap">
-              <span className="font-bold text-white">{t('evolution.step', { number: i + 1 })}</span>
-              <span className="font-mono text-slate-400 text-sm">
+            <div className="flex items-center gap-3 px-4 py-3 bg-muted flex-wrap">
+              <span className="font-bold text-foreground">{t('evolution.step', { number: i + 1 })}</span>
+              <span className="font-mono text-muted-foreground text-sm">
                 {step.childId.slice(0, 8)}
               </span>
               <span
@@ -251,7 +251,7 @@ export default function DiffViewer({
                   )
                 }
                 return (
-                  <div key={j} data-diff-type="context" className="text-slate-500">
+                  <div key={j} data-diff-type="context" className="text-muted-foreground">
                     {' '}
                     {line.content}
                   </div>

--- a/frontend/src/components/evolution/EvolutionDashboard.tsx
+++ b/frontend/src/components/evolution/EvolutionDashboard.tsx
@@ -344,7 +344,7 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
       {isComplete ? (
         <div>
           <div className="sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 pb-4">
-            <div className="flex items-center gap-1 border-b border-border">
+            <div className="flex items-center gap-1 border-b border-border" role="tablist" aria-label="Evolution results">
               {[
                 { value: 'overview', label: 'Overview' },
                 { value: 'lineage', label: 'Lineage' },
@@ -355,9 +355,12 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
               ].map((tab) => (
                 <button
                   key={tab.value}
+                  role="tab"
+                  aria-selected={activeTab === tab.value}
+                  aria-controls={`panel-${tab.value}`}
                   onClick={() => setActiveTab(tab.value)}
                   className={cn(
-                    'px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px',
+                    'px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-t-sm',
                     activeTab === tab.value
                       ? 'border-primary text-foreground'
                       : 'border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/30'
@@ -398,7 +401,7 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
           )}
           {activeTab === '3d-islands' && (
             <div className="mt-6">
-              <Suspense fallback={<div className="flex items-center justify-center h-[500px]"><p className="text-slate-400">Loading 3D view...</p></div>}>
+              <Suspense fallback={<div className="flex items-center justify-center h-[500px]"><p className="text-muted-foreground">Loading 3D view...</p></div>}>
                 <Islands3D
                   candidates={effectiveState.candidates}
                   migrations={effectiveState.migrations}
@@ -411,7 +414,7 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
           )}
           {activeTab === 'lineage' && (
             <div className="mt-6">
-              <Suspense fallback={<div className="flex items-center justify-center h-[500px]"><p className="text-slate-400">Loading 3D view...</p></div>}>
+              <Suspense fallback={<div className="flex items-center justify-center h-[500px]"><p className="text-muted-foreground">Loading 3D view...</p></div>}>
                 <Lineage3D
                   lineageEvents={results?.lineageEvents ?? []}
                   bestCandidateId={results?.bestCandidateId ?? null}

--- a/frontend/src/components/evolution/FitnessChart.tsx
+++ b/frontend/src/components/evolution/FitnessChart.tsx
@@ -54,8 +54,8 @@ export default function FitnessChart({ data, isLive = false }: FitnessChartProps
   const fitnessDomain: [number, number] = [fitnessMin - fitnessPadding, fitnessMax + fitnessPadding]
 
   return (
-    <div className="bg-slate-800 border border-slate-700 rounded-lg p-4">
-      <h3 className="text-slate-200 font-semibold mb-4">{t('evolution.fitnessProgression')}</h3>
+    <div className="bg-card border border-border rounded-lg p-4">
+      <h3 className="text-foreground font-semibold mb-4">{t('evolution.fitnessProgression')}</h3>
       {cleanData.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-[400px] gap-3">
           {isLive ? (
@@ -65,12 +65,12 @@ export default function FitnessChart({ data, isLive = false }: FitnessChartProps
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
                   <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
                 </span>
-                <p className="text-slate-400">{t('evolution.evaluatingFirstGeneration')}</p>
+                <p className="text-muted-foreground">{t('evolution.evaluatingFirstGeneration')}</p>
               </div>
-              <p className="text-slate-600 text-xs">{t('evolution.evaluatingFirstGenerationHint')}</p>
+              <p className="text-muted-foreground text-xs">{t('evolution.evaluatingFirstGenerationHint')}</p>
             </>
           ) : (
-            <p className="text-slate-500">{t('evolution.noDataYet')}</p>
+            <p className="text-muted-foreground">{t('evolution.noDataYet')}</p>
           )}
         </div>
       ) : (

--- a/frontend/src/components/evolution/Islands3D.tsx
+++ b/frontend/src/components/evolution/Islands3D.tsx
@@ -28,8 +28,8 @@ interface CanvasErrorBoundaryState { hasError: boolean }
 function CanvasRenderErrorFallback() {
   const { t } = useTranslation()
   return (
-    <div className="flex items-center justify-center h-[500px] bg-slate-800 border border-slate-700 rounded-lg">
-      <p className="text-slate-400">{t('evolution.webglRequired')}</p>
+    <div className="flex items-center justify-center h-[500px] bg-card border border-border rounded-lg">
+      <p className="text-muted-foreground">{t('evolution.webglRequired')}</p>
     </div>
   )
 }
@@ -149,7 +149,7 @@ function IslandSphere({ layout }: { layout: IslandLayout }) {
         />
       </mesh>
       <Html position={[0, ISLAND_RADIUS + 0.3, 0]} center>
-        <div className="text-xs text-slate-400 whitespace-nowrap select-none pointer-events-none">
+        <div className="text-xs text-muted-foreground whitespace-nowrap select-none pointer-events-none">
           Island {layout.index}
         </div>
       </Html>
@@ -744,10 +744,10 @@ function Islands3DScene({
   const isEmpty = candidates.length === 0 && islandCount === 0
 
   return (
-    <div ref={containerRef} className="bg-slate-800 border border-slate-700 rounded-lg p-4 h-[500px] relative">
+    <div ref={containerRef} className="bg-card border border-border rounded-lg p-4 h-[500px] relative">
       {isEmpty && (
         <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
-          <p className="text-slate-400">{t('evolution.noIslandDataToDisplay')}</p>
+          <p className="text-muted-foreground">{t('evolution.noIslandDataToDisplay')}</p>
         </div>
       )}
       <Canvas camera={{ position: [0, 0, 15], fov: 50 }}>
@@ -834,8 +834,8 @@ export default function Islands3D({
 }: Islands3DProps) {
   if (!isWebGLAvailable()) {
     return (
-      <div className="flex items-center justify-center h-[500px] bg-slate-800 border border-slate-700 rounded-lg">
-        <p className="text-slate-400">
+      <div className="flex items-center justify-center h-[500px] bg-card border border-border rounded-lg">
+        <p className="text-muted-foreground">
           WebGL is not supported in your browser. Use the 2D view instead.
         </p>
       </div>

--- a/frontend/src/components/evolution/IslandsView.tsx
+++ b/frontend/src/components/evolution/IslandsView.tsx
@@ -230,8 +230,8 @@ export default function IslandsView({ candidates, migrations, islandCount, statu
   const isEmpty = candidates.length === 0 && islandCount === 0
 
   return (
-    <div className="bg-slate-800 border border-slate-700 rounded-lg p-4">
-      <h3 className="text-sm font-medium text-slate-300 mb-3">{t('evolution.islands')}</h3>
+    <div className="bg-card border border-border rounded-lg p-4">
+      <h3 className="text-sm font-medium text-foreground mb-3">{t('evolution.islands')}</h3>
 
       {isEmpty ? (
         <div className="flex items-center justify-center min-h-[400px]">
@@ -374,7 +374,7 @@ export default function IslandsView({ candidates, migrations, islandCount, statu
           {/* Tooltip overlay */}
           {tooltip && (
             <div
-              className="absolute pointer-events-none bg-slate-900 text-slate-200 text-xs px-2 py-1 rounded border border-slate-600 whitespace-nowrap"
+              className="absolute pointer-events-none bg-background text-foreground text-xs px-2 py-1 rounded border border-border whitespace-nowrap"
               style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}
             >
               {tooltip.text}
@@ -403,17 +403,12 @@ export default function IslandsView({ candidates, migrations, islandCount, statu
 
           {/* Status-based migration display for tests (always shows if migrations exist) */}
           {migrations.length > 0 && !recentMigration && (
-            <div className="text-xs text-slate-500 mt-1">
+            <div className="text-xs text-muted-foreground mt-1">
               {migrations.length} migration{migrations.length !== 1 ? 's' : ''} recorded
             </div>
           )}
 
-          {/* CSS for dash animation */}
-          <style>{`
-            @keyframes dash {
-              to { stroke-dashoffset: -20; }
-            }
-          `}</style>
+
         </div>
       )}
     </div>

--- a/frontend/src/components/evolution/Lineage3D.tsx
+++ b/frontend/src/components/evolution/Lineage3D.tsx
@@ -345,7 +345,7 @@ function RegularNode({
 function NodeTooltip({ node }: { node: SimNode3D }) {
   return (
     <Html distanceFactor={10} style={{ pointerEvents: 'none' }}>
-      <div className="bg-slate-900 text-slate-200 text-xs px-3 py-2 rounded border border-slate-600 whitespace-nowrap">
+      <div className="bg-background text-foreground text-xs px-3 py-2 rounded border border-border whitespace-nowrap">
         <div className="font-mono font-bold">{node.id.slice(0, 8)}</div>
         <div>Fitness: {node.fitnessScore.toFixed(3)}</div>
         <div>Gen: {node.generation} | Island: {node.island}</div>
@@ -543,9 +543,9 @@ function Lineage3DScene({
   const lowDetail = edges.length > HELIX_DETAIL_THRESHOLD
 
   return (
-    <div ref={containerRef} className="bg-slate-800 border border-slate-700 rounded-lg p-4 h-[500px] relative">
+    <div ref={containerRef} className="bg-card border border-border rounded-lg p-4 h-[500px] relative">
       {/* Mutation type legend overlay */}
-      <div className="absolute top-3 right-3 z-10 bg-slate-900/80 border border-slate-700 rounded px-3 py-2 text-xs text-slate-300">
+      <div className="absolute top-3 right-3 z-10 bg-background/80 border border-border rounded px-3 py-2 text-xs text-foreground">
         {Object.entries(MUTATION_COLORS).map(([type, color]) => (
           <div key={type} className="flex items-center gap-2 py-0.5">
             <span
@@ -679,8 +679,8 @@ export default function Lineage3D({
 }: Lineage3DProps) {
   if (!isWebGLAvailable()) {
     return (
-      <div className="flex items-center justify-center h-[500px] bg-slate-800 border border-slate-700 rounded-lg">
-        <p className="text-slate-400">
+      <div className="flex items-center justify-center h-[500px] bg-card border border-border rounded-lg">
+        <p className="text-muted-foreground">
           WebGL is not supported in your browser. Use the 2D view instead.
         </p>
       </div>
@@ -689,8 +689,8 @@ export default function Lineage3D({
 
   if (lineageEvents.length === 0) {
     return (
-      <div className="flex items-center justify-center h-[500px] bg-slate-800 border border-slate-700 rounded-lg">
-        <p className="text-slate-400">No lineage data</p>
+      <div className="flex items-center justify-center h-[500px] bg-card border border-border rounded-lg">
+        <p className="text-muted-foreground">No lineage data</p>
       </div>
     )
   }

--- a/frontend/src/components/evolution/MutationStats.tsx
+++ b/frontend/src/components/evolution/MutationStats.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useMemo } from 'react'
 import type { LineageNode, MutationStat } from '../../types/evolution'
 import { MUTATION_COLORS } from '../../types/evolution'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 
 interface MutationStatsProps {
   lineageEvents: LineageNode[]
@@ -66,7 +67,7 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
 
   if (entries.length === 0) {
     return (
-      <div className="rounded-lg border border-slate-700 bg-slate-800/50 p-8 text-center text-slate-400">
+      <div className="rounded-lg border border-border bg-card/50 p-8 text-center text-muted-foreground">
         {t('evolution.noMutationData')}
       </div>
     )
@@ -75,8 +76,8 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
   return (
     <div className="space-y-4">
       {/* Distribution bar */}
-      <div className="rounded-lg border border-slate-700 bg-slate-800 p-4">
-        <p className="mb-2 text-xs font-medium uppercase tracking-wider text-slate-400">
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
           {t('evolution.mutationDistribution')}
         </p>
         <div className="flex h-4 overflow-hidden rounded-full">
@@ -94,7 +95,7 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
             )
           })}
         </div>
-        <div className="mt-2 flex flex-wrap gap-3 text-xs text-slate-400">
+        <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
           {entries.map(([mtype, s]) => (
             <span key={mtype} className="flex items-center gap-1">
               <span
@@ -110,29 +111,19 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
       </div>
 
       {/* Table */}
-      <div className="overflow-hidden rounded-lg border border-slate-700 bg-slate-800">
-        <table className="w-full">
-          <thead>
-            <tr className="bg-slate-700/50">
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-400">
-                {t('evolution.mutationType')}
-              </th>
-              <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-slate-400">
-                Count
-              </th>
-              <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-slate-400">
-                Improved
-              </th>
-              <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-slate-400">
-                Improvement Rate
-              </th>
-              <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-slate-400">
-                Avg Delta
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.map(([mtype, s], idx) => {
+      <div className="overflow-hidden rounded-lg border border-border bg-card">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted">
+              <TableHead>{t('evolution.mutationType')}</TableHead>
+              <TableHead className="text-right">Count</TableHead>
+              <TableHead className="text-right">Improved</TableHead>
+              <TableHead className="text-right">Improvement Rate</TableHead>
+              <TableHead className="text-right">Avg Delta</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.map(([mtype, s]) => {
               const rate = s.count > 0 ? (s.improved / s.count) * 100 : 0
               const deltaColor =
                 s.avgDelta > 0
@@ -142,13 +133,8 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
                     : '#94a3b8'
 
               return (
-                <tr
-                  key={mtype}
-                  className={`${
-                    idx % 2 === 0 ? 'bg-slate-800/50' : 'bg-slate-900/30'
-                  } hover:bg-slate-700/30`}
-                >
-                  <td className="px-4 py-3">
+                <TableRow key={mtype}>
+                  <TableCell>
                     <span
                       className="inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold"
                       style={{
@@ -158,28 +144,22 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
                     >
                       {mtype}
                     </span>
-                  </td>
-                  <td className="px-4 py-3 text-right text-sm text-slate-300">
-                    {s.count}
-                  </td>
-                  <td className="px-4 py-3 text-right text-sm text-slate-300">
-                    {s.improved}
-                  </td>
-                  <td className="px-4 py-3 text-right text-sm text-slate-300">
-                    {rate.toFixed(1)}%
-                  </td>
-                  <td
-                    className="px-4 py-3 text-right text-sm font-mono"
+                  </TableCell>
+                  <TableCell className="text-right">{s.count}</TableCell>
+                  <TableCell className="text-right">{s.improved}</TableCell>
+                  <TableCell className="text-right">{rate.toFixed(1)}%</TableCell>
+                  <TableCell
+                    className="text-right font-mono"
                     style={{ color: deltaColor }}
                   >
                     {s.avgDelta >= 0 ? '+' : ''}
                     {s.avgDelta.toFixed(4)}
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               )
             })}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
     </div>
   )

--- a/frontend/src/components/evolution/PhyloTree.tsx
+++ b/frontend/src/components/evolution/PhyloTree.tsx
@@ -251,17 +251,17 @@ export default function PhyloTree({ lineageEvents, bestCandidateId }: PhyloTreeP
 
   if (lineageEvents.length === 0) {
     return (
-      <div className="rounded-lg border border-slate-700 bg-slate-800/50 p-8 text-center">
+      <div className="rounded-lg border border-border bg-card/50 p-8 text-center">
         <p style={{ color: COLORS.textMuted }}>No lineage data</p>
       </div>
     )
   }
 
   return (
-    <div ref={containerRef} className="rounded-lg border border-slate-700 bg-slate-800/50 relative overflow-hidden">
+    <div ref={containerRef} className="rounded-lg border border-border bg-card/50 relative overflow-hidden">
       {/* Mutation Legend */}
-      <div className="absolute top-3 right-3 z-10 bg-slate-900/90 border border-slate-700 rounded-lg p-3">
-        <p className="text-xs font-medium text-slate-400 mb-2">Mutation Types</p>
+      <div className="absolute top-3 right-3 z-10 bg-background/90 border border-border rounded-lg p-3">
+        <p className="text-xs font-medium text-muted-foreground mb-2">Mutation Types</p>
         <div className="flex flex-col gap-1">
           {Object.entries(MUTATION_COLORS).map(([type, color]) => (
             <div key={type} className="flex items-center gap-2">
@@ -269,7 +269,7 @@ export default function PhyloTree({ lineageEvents, bestCandidateId }: PhyloTreeP
                 className="w-3 h-3 rounded-full inline-block"
                 style={{ backgroundColor: color }}
               />
-              <span className="text-xs text-slate-300">{type}</span>
+              <span className="text-xs text-foreground">{type}</span>
             </div>
           ))}
         </div>
@@ -400,7 +400,7 @@ export default function PhyloTree({ lineageEvents, bestCandidateId }: PhyloTreeP
       {/* Tooltip */}
       {tooltip && (
         <div
-          className="absolute pointer-events-none bg-slate-900 text-slate-200 text-xs px-3 py-2 rounded border border-slate-600 whitespace-nowrap z-20"
+          className="absolute pointer-events-none bg-background text-foreground text-xs px-3 py-2 rounded border border-border whitespace-nowrap z-20"
           style={{
             left: tooltip.x,
             top: tooltip.y,
@@ -438,21 +438,21 @@ export default function PhyloTree({ lineageEvents, bestCandidateId }: PhyloTreeP
         <button
           aria-label="Zoom in"
           onClick={handleZoomIn}
-          className="w-9 h-9 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-200 text-lg font-bold flex items-center justify-center border border-slate-600"
+          className="w-9 h-9 rounded-lg bg-secondary hover:bg-secondary/80 text-foreground text-lg font-bold flex items-center justify-center border border-border"
         >
           +
         </button>
         <button
           aria-label="Zoom out"
           onClick={handleZoomOut}
-          className="w-9 h-9 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-200 text-lg font-bold flex items-center justify-center border border-slate-600"
+          className="w-9 h-9 rounded-lg bg-secondary hover:bg-secondary/80 text-foreground text-lg font-bold flex items-center justify-center border border-border"
         >
           -
         </button>
         <button
           aria-label="Reset zoom"
           onClick={handleZoomReset}
-          className="w-9 h-9 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-200 text-xs font-medium flex items-center justify-center border border-slate-600"
+          className="w-9 h-9 rounded-lg bg-secondary hover:bg-secondary/80 text-foreground text-xs font-medium flex items-center justify-center border border-border"
         >
           1:1
         </button>

--- a/frontend/src/components/history/RunHistoryTable.tsx
+++ b/frontend/src/components/history/RunHistoryTable.tsx
@@ -229,8 +229,16 @@ export default function RunHistoryTable({ promptId: propPromptId }: RunHistoryTa
                 return (
                   <TableRow
                     key={run.id}
+                    tabIndex={0}
+                    role="link"
                     onClick={() => navigate(propPromptId ? `${run.id}` : `/history/${run.id}`)}
-                    className="cursor-pointer hover:bg-muted/50 transition-colors"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        navigate(propPromptId ? `${run.id}` : `/history/${run.id}`)
+                      }
+                    }}
+                    className="cursor-pointer hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   >
                     <TableCell className="font-mono text-xs">{run.id}</TableCell>
                     {!propPromptId && <TableCell>{run.prompt_id}</TableCell>}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -5,9 +5,15 @@ import { AppBreadcrumbs } from './Breadcrumbs'
 export default function AppShell() {
   return (
     <div className="flex h-screen bg-background text-foreground">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:m-2"
+      >
+        Skip to main content
+      </a>
       <Sidebar />
-      <main className="flex-1 overflow-auto">
-        <div className="p-6">
+      <main id="main-content" className="flex-1 overflow-auto">
+        <div className="p-6 md:p-6 p-4">
           <AppBreadcrumbs />
           <Outlet />
         </div>

--- a/frontend/src/components/layout/ErrorBoundary.tsx
+++ b/frontend/src/components/layout/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component } from 'react'
+import type { ReactNode, ErrorInfo } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-[400px] items-center justify-center p-8">
+          <div className="max-w-md text-center space-y-4">
+            <h2 className="text-lg font-semibold text-foreground">Something went wrong</h2>
+            <p className="text-sm text-muted-foreground">
+              {this.state.error?.message || 'An unexpected error occurred.'}
+            </p>
+            <Button
+              variant="outline"
+              onClick={() => this.setState({ hasError: false, error: null })}
+            >
+              Try again
+            </Button>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
-import { FileText, ChevronLeft, ChevronRight, Wand2, Dna, Settings, Globe } from 'lucide-react'
+import { FileText, ChevronLeft, ChevronRight, Wand2, Dna, Settings, Globe, Menu, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
@@ -38,8 +38,7 @@ function CollapsedLink({ to, label, children }: { to: string; label: string; chi
   )
 }
 
-export function Sidebar() {
-  const [collapsed, setCollapsed] = useState(false)
+function SidebarContent({ collapsed, setCollapsed, onNavClick }: { collapsed: boolean; setCollapsed: (v: boolean) => void; onNavClick?: () => void }) {
   const { t, i18n } = useTranslation()
 
   const currentLangIndex = LANGUAGES.findIndex((l) => l.value === i18n.language) ?? 0
@@ -52,142 +51,48 @@ export function Sidebar() {
   const currentLangLabel = LANGUAGES.find((l) => l.value === i18n.language)?.label ?? 'English'
 
   return (
-    <TooltipProvider delayDuration={0}>
-      <aside
-        className={cn(
-          'flex flex-col border-r border-sidebar-border bg-sidebar transition-[width] duration-200 ease-in-out',
-          collapsed ? 'w-14' : 'w-56'
+    <>
+      {/* Header */}
+      <div className={cn(
+        'flex h-14 items-center',
+        collapsed ? 'justify-center' : 'px-3'
+      )}>
+        {!collapsed && (
+          <span className="flex items-center gap-2 text-lg font-semibold text-sidebar-foreground truncate">
+            <Dna className="h-5 w-5 text-primary shrink-0" aria-hidden="true" />
+            Helix
+          </span>
         )}
-      >
-        {/* Header */}
-        <div className={cn(
-          'flex h-14 items-center',
-          collapsed ? 'justify-center' : 'px-3'
-        )}>
-          {!collapsed && (
-            <span className="flex items-center gap-2 text-lg font-semibold text-sidebar-foreground truncate">
-              <Dna className="h-5 w-5 text-primary shrink-0" />
-              Helix
-            </span>
-          )}
-          {collapsed && (
-            <Dna className="h-5 w-5 text-primary" />
-          )}
-        </div>
+        {collapsed && (
+          <Dna className="h-5 w-5 text-primary" aria-hidden="true" />
+        )}
+      </div>
 
-        {/* Toggle button */}
-        <div className={cn('flex', collapsed ? 'justify-center' : 'justify-end px-2')}>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setCollapsed(!collapsed)}
-            className="h-7 w-7 text-muted-foreground hover:text-foreground"
-          >
-            {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
-          </Button>
-        </div>
+      {/* Toggle button (desktop only) */}
+      <div className={cn('hidden md:flex', collapsed ? 'justify-center' : 'justify-end px-2')}>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setCollapsed(!collapsed)}
+          aria-label={collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
+          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+        >
+          {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+        </Button>
+      </div>
 
-        {/* Navigation */}
-        <nav className={cn('flex-1 py-2', collapsed ? '' : 'px-2')}>
-          <ul className={cn('flex flex-col', collapsed ? 'items-center gap-2' : 'gap-1')}>
-            <li>
-              {collapsed ? (
-                <CollapsedLink to="/prompts" label={t('sidebar.prompts')}>
-                  <FileText className="h-5 w-5" />
-                </CollapsedLink>
-              ) : (
-                <NavLink
-                  to="/prompts"
-                  className={({ isActive }) =>
-                    cn(
-                      'flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors',
-                      isActive
-                        ? 'bg-primary/15 text-primary ring-1 ring-primary/30'
-                        : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
-                    )
-                  }
-                >
-                  <FileText className="h-4 w-4" />
-                  {t('sidebar.prompts')}
-                </NavLink>
-              )}
-            </li>
-            <li>
-              {collapsed ? (
-                <CollapsedLink to="/wizard" label={t('sidebar.wizard')}>
-                  <Wand2 className="h-5 w-5" />
-                </CollapsedLink>
-              ) : (
-                <NavLink
-                  to="/wizard"
-                  className={({ isActive }) =>
-                    cn(
-                      'flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors',
-                      isActive
-                        ? 'bg-primary/15 text-primary ring-1 ring-primary/30'
-                        : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
-                    )
-                  }
-                >
-                  <Wand2 className="h-4 w-4" />
-                  {t('sidebar.wizard')}
-                </NavLink>
-              )}
-            </li>
-          </ul>
-        </nav>
-
-        {/* Bottom section: Language selector + Settings */}
-        <div className={cn('pb-3', collapsed ? '' : 'px-2')}>
-          <Separator className={cn('mb-2', collapsed && 'mx-auto w-10')} />
-
-          {/* Language selector */}
-          <div className={cn('mb-1', collapsed && 'flex justify-center')}>
+      {/* Navigation */}
+      <nav className={cn('flex-1 py-2', collapsed ? '' : 'px-2')} aria-label="Main navigation">
+        <ul className={cn('flex flex-col', collapsed ? 'items-center gap-2' : 'gap-1')}>
+          <li>
             {collapsed ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={cycleLanguage}
-                    className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
-                  >
-                    <Globe className="h-5 w-5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="right">
-                  {t('sidebar.language')}: {currentLangLabel}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <div className="flex h-10 items-center gap-3 rounded-md px-3">
-                <Globe className="h-4 w-4 text-muted-foreground shrink-0" />
-                <Select
-                  value={i18n.language}
-                  onValueChange={(value) => i18n.changeLanguage(value)}
-                >
-                  <SelectTrigger className="h-8 flex-1 text-sm border-0 bg-transparent px-0 shadow-none focus:ring-0">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {LANGUAGES.map((lang) => (
-                      <SelectItem key={lang.value} value={lang.value}>
-                        {lang.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </div>
-
-          {/* Settings link */}
-          <div className={cn(collapsed && 'flex justify-center')}>
-            {collapsed ? (
-              <CollapsedLink to="/settings" label={t('sidebar.settings')}>
-                <Settings className="h-5 w-5" />
+              <CollapsedLink to="/prompts" label={t('sidebar.prompts')}>
+                <FileText className="h-5 w-5" />
               </CollapsedLink>
             ) : (
               <NavLink
-                to="/settings"
+                to="/prompts"
+                onClick={onNavClick}
                 className={({ isActive }) =>
                   cn(
                     'flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors',
@@ -197,12 +102,170 @@ export function Sidebar() {
                   )
                 }
               >
-                <Settings className="h-4 w-4" />
-                {t('sidebar.settings')}
+                <FileText className="h-4 w-4" aria-hidden="true" />
+                {t('sidebar.prompts')}
               </NavLink>
             )}
-          </div>
+          </li>
+          <li>
+            {collapsed ? (
+              <CollapsedLink to="/wizard" label={t('sidebar.wizard')}>
+                <Wand2 className="h-5 w-5" />
+              </CollapsedLink>
+            ) : (
+              <NavLink
+                to="/wizard"
+                onClick={onNavClick}
+                className={({ isActive }) =>
+                  cn(
+                    'flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-primary/15 text-primary ring-1 ring-primary/30'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+                  )
+                }
+              >
+                <Wand2 className="h-4 w-4" aria-hidden="true" />
+                {t('sidebar.wizard')}
+              </NavLink>
+            )}
+          </li>
+        </ul>
+      </nav>
+
+      {/* Bottom section: Language selector + Settings */}
+      <div className={cn('pb-3', collapsed ? '' : 'px-2')}>
+        <Separator className={cn('mb-2', collapsed && 'mx-auto w-10')} />
+
+        {/* Language selector */}
+        <div className={cn('mb-1', collapsed && 'flex justify-center')}>
+          {collapsed ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={cycleLanguage}
+                  aria-label={`${t('sidebar.language')}: ${currentLangLabel}`}
+                  className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+                >
+                  <Globe className="h-5 w-5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                {t('sidebar.language')}: {currentLangLabel}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <div className="flex h-10 items-center gap-3 rounded-md px-3">
+              <Globe className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+              <Select
+                value={i18n.language}
+                onValueChange={(value) => i18n.changeLanguage(value)}
+              >
+                <SelectTrigger className="h-8 flex-1 text-sm border-0 bg-transparent px-0 shadow-none focus:ring-0">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {LANGUAGES.map((lang) => (
+                    <SelectItem key={lang.value} value={lang.value}>
+                      {lang.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
         </div>
+
+        {/* Settings link */}
+        <div className={cn(collapsed && 'flex justify-center')}>
+          {collapsed ? (
+            <CollapsedLink to="/settings" label={t('sidebar.settings')}>
+              <Settings className="h-5 w-5" />
+            </CollapsedLink>
+          ) : (
+            <NavLink
+              to="/settings"
+              onClick={onNavClick}
+              className={({ isActive }) =>
+                cn(
+                  'flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors',
+                  isActive
+                    ? 'bg-primary/15 text-primary ring-1 ring-primary/30'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+                )
+              }
+            >
+              <Settings className="h-4 w-4" aria-hidden="true" />
+              {t('sidebar.settings')}
+            </NavLink>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export function Sidebar() {
+  const [collapsed, setCollapsed] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const location = useLocation()
+
+  // Close mobile sidebar on route change
+  useEffect(() => {
+    setMobileOpen(false)
+  }, [location.pathname])
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      {/* Mobile hamburger button */}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => setMobileOpen(true)}
+        aria-label="Open navigation menu"
+        className="fixed top-3 left-3 z-50 md:hidden h-10 w-10"
+      >
+        <Menu className="h-5 w-5" />
+      </Button>
+
+      {/* Mobile overlay */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-background/80 backdrop-blur-sm md:hidden"
+          onClick={() => setMobileOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Mobile sidebar drawer */}
+      <aside
+        className={cn(
+          'fixed inset-y-0 left-0 z-50 flex w-56 flex-col border-r border-sidebar-border bg-sidebar transition-transform duration-200 ease-in-out md:hidden',
+          mobileOpen ? 'translate-x-0' : '-translate-x-full'
+        )}
+      >
+        <div className="absolute top-3 right-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setMobileOpen(false)}
+            aria-label="Close navigation menu"
+            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        <SidebarContent collapsed={false} setCollapsed={setCollapsed} onNavClick={() => setMobileOpen(false)} />
+      </aside>
+
+      {/* Desktop sidebar */}
+      <aside
+        className={cn(
+          'hidden md:flex flex-col border-r border-sidebar-border bg-sidebar transition-[width] duration-200 ease-in-out',
+          collapsed ? 'w-14' : 'w-56'
+        )}
+      >
+        <SidebarContent collapsed={collapsed} setCollapsed={setCollapsed} />
       </aside>
     </TooltipProvider>
   )

--- a/frontend/src/components/prompts/TemplateEditor.tsx
+++ b/frontend/src/components/prompts/TemplateEditor.tsx
@@ -76,7 +76,7 @@ export default function TemplateEditor({ promptId, initialTemplate, onSaved }: T
         </button>
         <button
           onClick={handleCancel}
-          className="inline-flex items-center rounded-md bg-slate-700 px-4 py-2 text-sm font-medium text-slate-200 hover:bg-slate-600 transition-colors"
+          className="inline-flex items-center rounded-md bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground hover:bg-secondary/80 transition-colors"
         >
           {t('common.cancel')}
         </button>

--- a/frontend/src/components/prompts/VersionDiffViewer.tsx
+++ b/frontend/src/components/prompts/VersionDiffViewer.tsx
@@ -31,9 +31,9 @@ export default function VersionDiffViewer({
   }, [fromTemplate, toTemplate, fromLabel, toLabel])
 
   return (
-    <div className="rounded-lg border border-slate-700 bg-slate-800/50 overflow-hidden">
+    <div className="rounded-lg border border-border bg-card/50 overflow-hidden">
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 py-3 bg-slate-700/50">
+      <div className="flex items-center gap-3 px-4 py-3 bg-muted">
         <span className="font-semibold text-foreground text-sm">
           {fromLabel} &rarr; {toLabel}
         </span>
@@ -82,7 +82,7 @@ export default function VersionDiffViewer({
                 )
               }
               return (
-                <div key={i} data-diff-type="context" className="text-slate-500">
+                <div key={i} data-diff-type="context" className="text-muted-foreground">
                   {' '}
                   {line.content}
                 </div>

--- a/frontend/src/components/prompts/VersionHistory.tsx
+++ b/frontend/src/components/prompts/VersionHistory.tsx
@@ -115,7 +115,7 @@ export default function VersionHistory({ promptId }: VersionHistoryProps) {
       {versions.map((ver) => (
         <div
           key={ver.version}
-          className="rounded-lg border border-slate-700 bg-slate-800/50 overflow-hidden"
+          className="rounded-lg border border-border bg-card/50 overflow-hidden"
         >
           {/* Version row header */}
           <div className="flex items-center gap-3 px-4 py-3">
@@ -125,7 +125,7 @@ export default function VersionHistory({ promptId }: VersionHistoryProps) {
                 type="checkbox"
                 checked={selectedForDiff.has(ver.version)}
                 onChange={() => toggleDiffSelection(ver.version)}
-                className="h-4 w-4 rounded border-slate-600 bg-slate-700 text-emerald-500 focus:ring-emerald-500/50"
+                className="h-4 w-4 rounded border-border bg-secondary text-emerald-500 focus:ring-emerald-500/50"
                 title="Select for diff comparison"
               />
             )}
@@ -173,8 +173,8 @@ export default function VersionHistory({ promptId }: VersionHistoryProps) {
 
           {/* Expanded template view */}
           {expandedVersion === ver.version && (
-            <div className="border-t border-slate-700 px-4 py-3">
-              <pre className="font-mono text-xs leading-relaxed text-slate-400 overflow-x-auto whitespace-pre-wrap max-h-96 overflow-y-auto">
+            <div className="border-t border-border px-4 py-3">
+              <pre className="font-mono text-xs leading-relaxed text-muted-foreground overflow-x-auto whitespace-pre-wrap max-h-96 overflow-y-auto">
                 {ver.template}
               </pre>
             </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -92,3 +92,22 @@
     font-family: system-ui, -apple-system, sans-serif;
   }
 }
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Dash animation for island migration lines (moved from inline <style>) */
+@keyframes dash {
+  to {
+    stroke-dashoffset: -20;
+  }
+}


### PR DESCRIPTION
## Summary

Addresses critical and high-severity findings from a comprehensive frontend UI audit ([#35](https://github.com/Onebu/Helix/issues/35)).

- **Theming**: Replace 115+ hardcoded `bg-slate-*`/`text-slate-*`/`border-slate-*` classes across 13 components with design token classes (`bg-card`, `text-foreground`, `border-border`, etc.) — zero slate classes remain in components
- **Accessibility**: Add skip-nav link, keyboard navigation for clickable table rows, ARIA tab roles, SVG icon labels, `htmlFor` associations, focus-visible rings, `prefers-reduced-motion` support
- **Responsive**: Add mobile sidebar with hamburger menu + overlay drawer, fix sheet overflow on mobile
- **Resilience**: Add React ErrorBoundary, replace raw `<table>` with shadcn Table, move inline `<style>` to global CSS

22 files changed, 463 insertions, 312 deletions. All 203 tests passing.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — 25/25 test files, 203/203 tests passing
- [x] Updated layout tests for dual mobile/desktop sidebar
- [x] Updated case-results test for new tier badge classes
- [x] Manual: verify sidebar collapse/expand on desktop
- [x] Manual: verify mobile hamburger menu opens/closes sidebar overlay
- [x] Manual: verify keyboard Tab through clickable table rows
- [x] Manual: verify skip-nav link appears on focus

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)