### PR TITLE
perf: route-based code splitting — 90% smaller initial bundle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,28 +4,38 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AppShell from './components/layout/AppShell'
 import { PromptLayout } from './components/layout/PromptLayout'
 import PromptsPage from './pages/PromptsPage'
-import PromptTemplatePage from './pages/PromptTemplatePage'
-import PromptDatasetPage from './pages/PromptDatasetPage'
-import PromptEvolutionPage from './pages/PromptEvolutionPage'
-import PromptConfigPage from './pages/PromptConfigPage'
-import PromptHistoryPage from './pages/PromptHistoryPage'
-import RunDetailPage from './pages/RunDetailPage'
-import PromptPlaygroundPage from './pages/PromptPlaygroundPage'
-import WizardPage from './pages/WizardPage'
 
+// Route-based code splitting: each page loads only when navigated to
+const PromptTemplatePage = lazy(() => import('./pages/PromptTemplatePage'))
+const PromptDatasetPage = lazy(() => import('./pages/PromptDatasetPage'))
+const PromptEvolutionPage = lazy(() => import('./pages/PromptEvolutionPage'))
+const PromptConfigPage = lazy(() => import('./pages/PromptConfigPage'))
+const PromptHistoryPage = lazy(() => import('./pages/PromptHistoryPage'))
+const RunDetailPage = lazy(() => import('./pages/RunDetailPage'))
+const PromptPlaygroundPage = lazy(() => import('./pages/PromptPlaygroundPage'))
+const WizardPage = lazy(() => import('./pages/WizardPage'))
 const SettingsPage = lazy(() => import('./pages/SettingsPage'))
 
 const queryClient = new QueryClient()
+
+function PageFallback() {
+  return (
+    <div className="flex items-center justify-center py-20">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+    </div>
+  )
+}
 
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
+        <Suspense fallback={<PageFallback />}>
         <Routes>
           <Route element={<AppShell />}>
             <Route path="/prompts" element={<PromptsPage />} />
             <Route path="/wizard" element={<WizardPage />} />
-            <Route path="/settings" element={<Suspense fallback={null}><SettingsPage /></Suspense>} />
+            <Route path="/settings" element={<SettingsPage />} />
             <Route path="/prompts/:promptId" element={<PromptLayout />}>
               <Route index element={<Navigate to="template" replace />} />
               <Route path="template" element={<PromptTemplatePage />} />
@@ -44,6 +54,7 @@ export default function App() {
             <Route path="/" element={<Navigate to="/prompts" replace />} />
           </Route>
         </Routes>
+        </Suspense>
       </BrowserRouter>
     </QueryClientProvider>
   )

--- a/frontend/src/components/evolution/CaseResultsGrid.tsx
+++ b/frontend/src/components/evolution/CaseResultsGrid.tsx
@@ -252,11 +252,11 @@ export default function CaseResultsGrid({
         </div>
         <div className="flex h-2 overflow-hidden rounded-full bg-slate-700">
           <div
-            className="bg-emerald-500 transition-all"
+            className="bg-emerald-500 transition-[width]"
             style={{ width: `${passRate}%` }}
           />
           <div
-            className="bg-red-500 transition-all"
+            className="bg-red-500 transition-[width]"
             style={{ width: `${100 - passRate}%` }}
           />
         </div>

--- a/frontend/src/components/history/RunHistoryTable.tsx
+++ b/frontend/src/components/history/RunHistoryTable.tsx
@@ -119,6 +119,7 @@ export default function RunHistoryTable({ promptId: propPromptId }: RunHistoryTa
     queryKey: ['active-runs'],
     queryFn: () => listActiveRunsApiEvolutionActiveGet(),
     refetchInterval: 5000,
+    refetchIntervalInBackground: false,
   })
   const allActiveRuns: EvolutionRunStatus[] = (activeRunsResp?.data as EvolutionRunStatus[] | undefined) ?? []
   // Filter active runs to only those matching the selected prompt (if one is selected)

--- a/frontend/src/components/prompts/PromptCard.tsx
+++ b/frontend/src/components/prompts/PromptCard.tsx
@@ -16,7 +16,7 @@ export function PromptCard({ id, purpose, variableCount, anchorCount }: PromptCa
 
   return (
     <Link to={`/prompts/${id}`} className="group">
-      <Card className="relative overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-sm transition-all duration-300 cursor-pointer group-hover:shadow-lg group-hover:shadow-primary/5 group-hover:border-primary/50">
+      <Card className="relative overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-sm transition-[box-shadow,border-color] duration-300 cursor-pointer group-hover:shadow-lg group-hover:shadow-primary/5 group-hover:border-primary/50">
         <div className="absolute inset-0 rounded-lg bg-gradient-to-r from-primary/10 via-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
         <CardHeader>
           <div className="flex items-start gap-2">

--- a/frontend/src/pages/PromptEvolutionPage.tsx
+++ b/frontend/src/pages/PromptEvolutionPage.tsx
@@ -1,8 +1,17 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, lazy, Suspense } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import RunConfigForm from '@/components/evolution/RunConfigForm'
-import EvolutionDashboard from '@/components/evolution/EvolutionDashboard'
+
+const EvolutionDashboard = lazy(() => import('@/components/evolution/EvolutionDashboard'))
+
+function DashboardFallback() {
+  return (
+    <div className="flex items-center justify-center py-20">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+    </div>
+  )
+}
 
 export default function PromptEvolutionPage() {
   const { promptId } = useParams<{ promptId: string }>()
@@ -35,7 +44,9 @@ export default function PromptEvolutionPage() {
             {t('evolution.startNewRun')}
           </button>
         </div>
-        <EvolutionDashboard runId={activeRunId} />
+        <Suspense fallback={<DashboardFallback />}>
+          <EvolutionDashboard runId={activeRunId} />
+        </Suspense>
       </div>
     )
   }

--- a/frontend/src/pages/PromptTemplatePage.tsx
+++ b/frontend/src/pages/PromptTemplatePage.tsx
@@ -1,12 +1,13 @@
-import { useState } from 'react'
+import { useState, lazy, Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { getPromptApiPromptsPromptIdGet } from '@/client/sdk.gen'
 import { Button } from '@/components/ui/button'
 import PromptDetail from '@/components/prompts/PromptDetail'
-import TemplateEditor from '@/components/prompts/TemplateEditor'
 import VersionHistory from '@/components/prompts/VersionHistory'
+
+const TemplateEditor = lazy(() => import('@/components/prompts/TemplateEditor'))
 
 export default function PromptTemplatePage() {
   const { promptId } = useParams<{ promptId: string }>()
@@ -46,11 +47,17 @@ export default function PromptTemplatePage() {
               {t('common.cancel')}
             </Button>
           </div>
-          <TemplateEditor
-            promptId={promptId}
-            initialTemplate={prompt?.data?.template ?? ''}
-            onSaved={() => setEditing(false)}
-          />
+          <Suspense fallback={
+            <div className="flex items-center justify-center py-20">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+            </div>
+          }>
+            <TemplateEditor
+              promptId={promptId}
+              initialTemplate={prompt?.data?.template ?? ''}
+              onSaved={() => setEditing(false)}
+            />
+          </Suspense>
         </div>
       )}
     </div>

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -1,6 +1,8 @@
+import { lazy, Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import EvolutionDashboard from '../components/evolution/EvolutionDashboard'
+
+const EvolutionDashboard = lazy(() => import('../components/evolution/EvolutionDashboard'))
 
 export default function RunDetailPage() {
   const { runId } = useParams<{ runId: string }>()
@@ -12,7 +14,13 @@ export default function RunDetailPage() {
 
   return (
     <div>
-      <EvolutionDashboard runId={runId} />
+      <Suspense fallback={
+        <div className="flex items-center justify-center py-20">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+        </div>
+      }>
+        <EvolutionDashboard runId={runId} />
+      </Suspense>
     </div>
   )
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,29 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom/') || id.includes('node_modules/react-router') || id.includes('@tanstack/react-query')) {
+            return 'vendor-react'
+          }
+          if (id.includes('node_modules/recharts') || id.includes('node_modules/victory-vendor')) {
+            return 'vendor-recharts'
+          }
+          if (id.includes('node_modules/d3-')) {
+            return 'vendor-d3'
+          }
+          if (id.includes('node_modules/monaco-editor') || id.includes('@monaco-editor')) {
+            return 'vendor-monaco'
+          }
+          if (id.includes('node_modules/i18next') || id.includes('react-i18next')) {
+            return 'vendor-i18n'
+          }
+        },
+      },
+    },
+  },
   server: {
     host: '0.0.0.0',
     watch: {


### PR DESCRIPTION
## Summary

The main JavaScript bundle was **1,194 kB** because only 1 of 9 page components was lazy-loaded, and heavy libraries (Recharts, D3, Monaco, diff) were all eagerly imported.

### Changes

- **Lazy-load all page components** via `React.lazy()` in App.tsx with a shared Suspense spinner
- **Lazy-load EvolutionDashboard** inside its consumer pages — Recharts (292 kB), D3 (74 kB), and diff only load when visiting evolution routes
- **Lazy-load TemplateEditor** (Monaco) — only loads when user clicks Edit
- **Vite manualChunks** splits vendor libs into independently cacheable chunks
- **Runtime fixes**: stop polling in background tabs, narrow `transition-all` to specific properties

### Results

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Main bundle | 1,194 kB | 123 kB | **-90%** |
| Initial page load | ~1,194 kB | ~437 kB | **-63%** |
| Evolution-specific code | in main | 417 kB on-demand | deferred |
| Monaco editor | in main | 14 kB on-demand | deferred |

### Bundle breakdown (after)

| Chunk | Size | Loads when |
|-------|------|-----------|
| `index.js` | 123 kB | Always (app shell + prompts list) |
| `vendor-react` | 251 kB | Always (cacheable) |
| `vendor-i18n` | 63 kB | Always (cacheable) |
| `vendor-recharts` | 292 kB | Evolution route only |
| `vendor-d3` | 74 kB | Evolution route only |
| `EvolutionDashboard` | 51 kB | Evolution route only |
| `vendor-monaco` | 14 kB | Template edit only |

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — 25/25 test files, 203/203 tests passing
- [x] `npm run build` — no warnings except pre-existing Three.js chunk size
- [x] Manual: navigate between all routes, verify lazy loading works
- [x] Manual: verify spinner shows briefly on first route navigation
- [x] Manual: verify evolution dashboard loads correctly after lazy load

🤖 Generated with [Claude Code](https://claude.com/claude-code)