### PR TITLE
fix: strip google/ prefix from Gemini model names

### DIFF
--- a/api/gateway/litellm_provider.py
+++ b/api/gateway/litellm_provider.py
@@ -103,6 +103,8 @@ class LiteLLMProvider:
             RetryableError: On 429 or 5xx (triggers retry).
             GatewayError: On non-retryable errors (400, 401, etc.).
         """
+        model = self._normalize_model(model)
+
         async with self._semaphore:
             try:
                 response = await self._client.chat.completions.create(
@@ -151,6 +153,17 @@ class LiteLLMProvider:
             timestamp=datetime.now(UTC),
             finish_reason=choice.finish_reason,
         )
+
+    def _normalize_model(self, model: str) -> str:
+        """Normalize model name for the configured provider.
+
+        Strips the ``google/`` prefix when using the Gemini provider directly,
+        since that prefix is an OpenRouter convention and causes 404s on the
+        native Gemini API.
+        """
+        if self._provider == "gemini" and model.startswith("google/"):
+            return model[len("google/"):]
+        return model
 
     def _extract_cost(self, model: str, input_tokens: int, output_tokens: int) -> float:
         """Extract or estimate cost for a completion.

--- a/api/web/routers/playground.py
+++ b/api/web/routers/playground.py
@@ -240,7 +240,7 @@ async def _sse_generator(config: GeneConfig, messages: list[dict]):
     """
     provider = create_provider(config.target_provider, config)
 
-    target_model = config.target_model
+    target_model = provider._normalize_model(config.target_model)
     temperature = config.target_temperature or config.generation.temperature
 
     # Build streaming kwargs

--- a/tests/api/test_playground_chat.py
+++ b/tests/api/test_playground_chat.py
@@ -63,6 +63,7 @@ def _build_mock_provider(chunks):
         return_value=_mock_stream(*chunks)
     )
     mock_provider.close = AsyncMock()
+    mock_provider._normalize_model = lambda model: model
     return mock_provider
 
 

--- a/tests/gateway/test_litellm_provider.py
+++ b/tests/gateway/test_litellm_provider.py
@@ -66,6 +66,41 @@ class TestProviderInit:
             LiteLLMProvider(provider="unsupported", api_key="k")
 
 
+class TestModelNameNormalization:
+    """Test model name normalization for different providers."""
+
+    def test_gemini_strips_google_prefix(self):
+        provider = LiteLLMProvider(provider="gemini", api_key="k")
+        assert provider._normalize_model("google/gemini-3-flash-preview") == "gemini-3-flash-preview"
+
+    def test_gemini_preserves_plain_name(self):
+        provider = LiteLLMProvider(provider="gemini", api_key="k")
+        assert provider._normalize_model("gemini-2.5-flash") == "gemini-2.5-flash"
+
+    def test_openrouter_keeps_google_prefix(self):
+        provider = LiteLLMProvider(provider="openrouter", api_key="k")
+        assert provider._normalize_model("google/gemini-3-flash-preview") == "google/gemini-3-flash-preview"
+
+    def test_openai_keeps_model_unchanged(self):
+        provider = LiteLLMProvider(provider="openai", api_key="k")
+        assert provider._normalize_model("gpt-4o") == "gpt-4o"
+
+    async def test_gemini_chat_completion_strips_prefix(self):
+        """Model name is normalized before API call."""
+        mock_response = _mock_completion(model="gemini-3-flash-preview")
+        provider = LiteLLMProvider(provider="gemini", api_key="test-key")
+        provider._client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        await provider.chat_completion(
+            messages=[{"role": "user", "content": "Hi"}],
+            model="google/gemini-3-flash-preview",
+            role=ModelRole.TARGET,
+        )
+
+        call_kwargs = provider._client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "gemini-3-flash-preview"
+
+
 class TestChatCompletion:
     """Test basic chat completion functionality."""
 


### PR DESCRIPTION
## Summary
- Adds `_normalize_model()` to `LiteLLMProvider` that strips the `google/` prefix when provider is `gemini`
- Fixes the playground SSE streaming path which bypassed `chat_completion()` and called `provider._client` directly — now also applies model normalization
- Adds 5 unit tests for normalization + updates playground chat mock

## Test plan
- [x] Unit tests: 1198 passed (5 new normalization tests)
- [x] Docker build: succeeds
- [x] API test: set `google/gemini-2.5-flash` on gemini provider, playground chat returns successful response
- [x] Chrome UI test: confirmed via browser — model badge shows `gemini / google/gemini-2.5-flash`, chat works without 404

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)