### PR TITLE
feat: normalize design system with semantic color tokens

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -8,14 +8,67 @@ Prompt engineers working solo or in teams, ranging from people with minor prompt
 
 ### Aesthetic Direction
 - **Reference**: Linear — polish, clarity, purposeful motion, information density without clutter
-- **Theme**: Both light and dark mode (currently dark-only, needs light mode)
-- **Brand color**: Green/bio direction — lean into the DNA/evolution metaphor. The neon green helix logo is the brand anchor, not the current blue primary
-- **Typography**: Practical and readable for daily development use — not decorative, but not boring system defaults either. A clean geometric sans that feels modern and technical
-- **Visualizations**: The current lineage/islands views need improvement — they don't clearly communicate relationships and evolution paths. Clarity of data flow is paramount
+- **Anti-reference**: Avoid Grafana-style density overload or raw-data-dump aesthetics. Avoid playful/casual UIs that undermine the scientific precision feel
+- **Theme**: Both light and dark mode. Dark is primary. Neither should feel like an afterthought
+- **Brand color**: Green/bio direction — DNA/evolution metaphor. Primary green at oklch(0.6 0.19 155) / #22c55e. All neutrals tinted toward hue 155 for brand cohesion
+- **Color space**: OKLCH for perceptual uniformity across themes
+- **Typography**: DM Sans — clean geometric sans-serif. Practical, modern, technical. Not decorative
+- **Visualizations**: Lineage/islands views should clearly communicate relationships and evolution paths. Clarity of data flow is paramount
+- **Completion tone**: Quiet confidence — "your prompt improved 23%" not "you crushed it". Results speak for themselves
 
 ### Design Principles
 1. **Clarity over decoration** — Every element must communicate. If it doesn't help the user understand their data or take action, remove it.
 2. **Progressive disclosure** — Simple surface, depth on demand. Basic controls visible, advanced behind expandable sections. Newcomers aren't overwhelmed, experts aren't limited.
 3. **Evolution is visible** — The core metaphor (genetic evolution of prompts) should be tangible in the UI. Users should see lineage, improvement, and branching — not just numbers.
 4. **Precision feels approachable** — Scientific rigor in the data presentation, but warm and usable in the interaction design. Confidence without intimidation.
-5. **Dual-mode first** — Design for both light and dark from the start. Neither should feel like an afterthought.
+5. **Dual-mode first** — Design for both light and dark from the start.
+
+### Design System Reference
+
+#### Colors
+| Token | Light | Dark | Usage |
+|-------|-------|------|-------|
+| `--primary` | oklch(0.6 0.19 155) | oklch(0.65 0.19 155) | Brand green, CTAs, focus rings |
+| `--background` | oklch(0.98 0.004 155) | oklch(0.135 0.012 155) | Page background |
+| `--card` | oklch(1 0.002 155) | oklch(0.185 0.014 155) | Card surfaces |
+| `--foreground` | oklch(0.15 0.015 155) | oklch(0.96 0.006 155) | Primary text |
+| `--muted-foreground` | oklch(0.46 0.02 155) | oklch(0.65 0.015 155) | Secondary text |
+| `--border` | oklch(0.15 0.015 155 / 12%) | oklch(1 0 0 / 10%) | Borders |
+| `--destructive` | oklch(0.577 0.245 27.325) | same | Errors, destructive actions |
+
+#### Mutation Colors (evolution viz)
+| Type | Color | Hex |
+|------|-------|-----|
+| RCC | Green | #22c55e |
+| Structural | Amber | #f59e0b |
+| Fresh | Purple | #8b5cf6 |
+| Migrated | Blue | #3b82f6 |
+| Reset | Red | #ef4444 |
+| Seed | Slate | #94a3b8 |
+
+#### Typography
+- **Font**: `'DM Sans', system-ui, sans-serif`
+- **Sizes**: xs (12px), sm (14px), base (16px), lg/xl+ for headings
+- **Weights**: normal (body), medium (buttons), semibold (headings)
+
+#### Spacing
+- **Base unit**: 4px (Tailwind default)
+- **Card padding**: 24px (p-6)
+- **Component gaps**: 8-16px (gap-2 to gap-4)
+- **Section gaps**: 24px (gap-6)
+- **Border radius**: 10px base (--radius: 0.625rem), scaled via multipliers
+
+#### Component Stack
+- shadcn/ui (Radix primitives + CVA)
+- Recharts (fitness charts)
+- Lucide React (icons)
+- Monaco Editor (code editing)
+- Custom SVG (lineage graph, island summary)
+
+### Accessibility
+- WCAG AA contrast minimum
+- Focus rings: `ring-2 ring-ring ring-offset-2`
+- Respects `prefers-reduced-motion`
+- Skip-to-main-content link
+- Semantic HTML throughout
+- Touch targets: 40-44px minimum

--- a/frontend/src/__tests__/case-results.test.tsx
+++ b/frontend/src/__tests__/case-results.test.tsx
@@ -48,8 +48,8 @@ describe('CaseResultsGrid', () => {
     const criticalBadge = screen.getByText('critical')
     const normalBadge = screen.getByText('normal')
     const lowBadge = screen.getByText('low')
-    expect(criticalBadge.className).toContain('text-red')
-    expect(normalBadge.className).toContain('text-blue')
+    expect(criticalBadge.className).toContain('text-destructive')
+    expect(normalBadge.className).toContain('text-info')
     expect(lowBadge.className).toContain('text-muted-foreground')
   })
 

--- a/frontend/src/__tests__/diff-viewer.test.tsx
+++ b/frontend/src/__tests__/diff-viewer.test.tsx
@@ -88,7 +88,7 @@ describe('DiffViewer', () => {
     expect(addedLines.length).toBeGreaterThan(0)
     // Check that added lines have green text color class
     const firstAdded = addedLines[0] as HTMLElement
-    expect(firstAdded.className).toMatch(/emerald/)
+    expect(firstAdded.className).toMatch(/diff-add/)
   })
 
   it('deleted lines are rendered with red color class and line-through', () => {
@@ -99,7 +99,7 @@ describe('DiffViewer', () => {
     const deletedLines = container.querySelectorAll('[data-diff-type="del"]')
     expect(deletedLines.length).toBeGreaterThan(0)
     const firstDeleted = deletedLines[0] as HTMLElement
-    expect(firstDeleted.className).toMatch(/red/)
+    expect(firstDeleted.className).toMatch(/diff-del/)
     expect(firstDeleted.className).toMatch(/line-through/)
   })
 
@@ -167,7 +167,7 @@ describe('DiffViewer', () => {
       <DiffViewer lineageEvents={events} bestCandidateId="cand-003" />,
     )
     // No migration annotations should exist
-    const migrationAnnotations = container.querySelectorAll('.text-purple-400')
+    const migrationAnnotations = container.querySelectorAll('.text-mutation-fresh')
     expect(migrationAnnotations.length).toBe(0)
   })
 })

--- a/frontend/src/components/datasets/CaseImport.tsx
+++ b/frontend/src/components/datasets/CaseImport.tsx
@@ -81,7 +81,7 @@ export function CaseImport({ promptId, open, onOpenChange }: CaseImportProps) {
 
         {importedCount !== null ? (
           <div className="text-center py-4">
-            <p className="text-emerald-400 text-sm mb-4">
+            <p className="text-success text-sm mb-4">
               {t('datasets.importSuccess', { count: importedCount })}
             </p>
             <Button onClick={handleClose}>{t('datasets.done')}</Button>

--- a/frontend/src/components/datasets/CaseList.tsx
+++ b/frontend/src/components/datasets/CaseList.tsx
@@ -31,28 +31,28 @@ function ScorerFlags({ expectedOutput }: { expectedOutput: Record<string, unknow
   const flags: React.ReactNode[] = []
   if (expectedOutput.require_content === true) {
     flags.push(
-      <Badge key="rc" variant="outline" className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20" title="Require Content — response must not be empty">
+      <Badge key="rc" variant="outline" className="bg-success/10 text-success border-success/20" title="Require Content — response must not be empty">
         RC
       </Badge>
     )
   }
   if (expectedOutput.match_args != null) {
     flags.push(
-      <Badge key="ma" variant="outline" className="bg-blue-500/10 text-blue-400 border-blue-500/20" title="Match Args — response must call the expected tool">
+      <Badge key="ma" variant="outline" className="bg-info/10 text-info border-info/20" title="Match Args — response must call the expected tool">
         MA
       </Badge>
     )
   }
   if (expectedOutput.must_contain != null) {
     flags.push(
-      <Badge key="mc" variant="outline" className="bg-amber-500/10 text-amber-400 border-amber-500/20" title="Must Contain — response must include specific text">
+      <Badge key="mc" variant="outline" className="bg-warning/10 text-warning border-warning/20" title="Must Contain — response must include specific text">
         MC
       </Badge>
     )
   }
   if (expectedOutput.behavior_criteria != null) {
     flags.push(
-      <Badge key="bj" variant="outline" className="bg-purple-500/10 text-purple-400 border-purple-500/20" title="Behavior Judge — LLM evaluates against criteria">
+      <Badge key="bj" variant="outline" className="bg-mutation-fresh/10 text-mutation-fresh border-mutation-fresh/20" title="Behavior Judge — LLM evaluates against criteria">
         BJ
       </Badge>
     )

--- a/frontend/src/components/datasets/ReviewConversation.tsx
+++ b/frontend/src/components/datasets/ReviewConversation.tsx
@@ -43,7 +43,7 @@ function truncate(text: string, max: number): string {
 
 function scoreColor(passed: boolean | null): string {
   if (passed === null) return 'bg-muted text-muted-foreground'
-  return passed ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30' : 'bg-amber-500/10 text-amber-400 border-amber-500/30'
+  return passed ? 'bg-success/10 text-success border-success/30' : 'bg-warning/10 text-warning border-warning/30'
 }
 
 export function ReviewConversation({
@@ -300,7 +300,7 @@ export function ReviewConversation({
                 <Button
                   variant="outline"
                   size="sm"
-                  className="text-emerald-400 border-emerald-500/30 hover:bg-emerald-500/10"
+                  className="text-success border-success/30 hover:bg-success/10"
                   onClick={() => onApprove(index)}
                 >
                   <Check className="h-3.5 w-3.5 mr-1" />
@@ -323,7 +323,7 @@ export function ReviewConversation({
             )}
             {decision === 'approved' && (
               <>
-                <Badge className="bg-emerald-500/10 text-emerald-400 border-emerald-500/30">
+                <Badge className="bg-success/10 text-success border-success/30">
                   {t('datasets.approved')}
                 </Badge>
                 <button

--- a/frontend/src/components/datasets/SynthesisDialog.tsx
+++ b/frontend/src/components/datasets/SynthesisDialog.tsx
@@ -618,7 +618,7 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
                 <p className="text-xs text-muted-foreground truncate">{progressText}</p>
                 {conversations.length > 0 && (
                   <div className="flex gap-3 text-xs">
-                    <span className="text-emerald-400">{t('datasets.passed', { count: passedCount })}</span>
+                    <span className="text-success">{t('datasets.passed', { count: passedCount })}</span>
                     <span className="text-destructive">{t('datasets.failed', { count: failedCount })}</span>
                   </div>
                 )}
@@ -629,7 +629,7 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <Check className="h-4 w-4 text-emerald-400" />
+                    <Check className="h-4 w-4 text-success" />
                     <span className="text-sm font-medium text-foreground">{t('datasets.synthesisComplete')}</span>
                   </div>
                   <button
@@ -641,7 +641,7 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
                 </div>
                 <div className="flex gap-4 text-xs">
                   <span>{result.total} {t('datasets.generated')}</span>
-                  <span className="text-emerald-400">{result.persisted} {t('datasets.saved')}</span>
+                  <span className="text-success">{result.persisted} {t('datasets.saved')}</span>
                   <span className="text-muted-foreground">{result.discarded} {t('datasets.discarded')}</span>
                 </div>
               </div>
@@ -883,7 +883,7 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
                       {conv.personaId} #{conv.conversationIndex + 1}
                     </span>
                     {conv.hasToolCalls && (
-                      <Badge variant="outline" className="text-xs gap-1 bg-amber-500/10 border-amber-500/30">
+                      <Badge variant="outline" className="text-xs gap-1 bg-warning/10 border-warning/30">
                         <Wrench className="h-2.5 w-2.5" />
                         tools
                       </Badge>
@@ -908,7 +908,7 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
                   <p className="text-xs text-muted-foreground">{t('datasets.generated')}</p>
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-emerald-400">{result.persisted}</p>
+                  <p className="text-2xl font-bold text-success">{result.persisted}</p>
                   <p className="text-xs text-muted-foreground">{t('datasets.persisted')}</p>
                 </div>
                 <div>
@@ -933,13 +933,13 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
                       {conv.personaId} #{conv.conversationIndex + 1}
                     </span>
                     {conv.hasToolCalls && (
-                      <Badge variant="outline" className="text-xs gap-1 bg-amber-500/10 border-amber-500/30">
+                      <Badge variant="outline" className="text-xs gap-1 bg-warning/10 border-warning/30">
                         <Wrench className="h-2.5 w-2.5" />
                         tools
                       </Badge>
                     )}
                     {conv.caseId && (
-                      <span className="text-xs text-emerald-400 ml-auto">{t('datasets.saved')}</span>
+                      <span className="text-xs text-success ml-auto">{t('datasets.saved')}</span>
                     )}
                   </div>
                 ))}
@@ -970,7 +970,7 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
               <Badge variant="outline" className="text-xs">
                 {t('datasets.conversations', { count: reviewConversations.length })}
               </Badge>
-              <span className="text-emerald-400">{reviewApprovedCount} {t('datasets.approved')}</span>
+              <span className="text-success">{reviewApprovedCount} {t('datasets.approved')}</span>
               <span className="text-destructive">{reviewRejectedCount} {t('datasets.rejected')}</span>
               <span className="text-muted-foreground">{reviewPendingCount} {t('datasets.pending')}</span>
             </div>
@@ -980,7 +980,7 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
               <Button
                 variant="outline"
                 size="sm"
-                className="text-emerald-400 border-emerald-500/30 hover:bg-emerald-500/10"
+                className="text-success border-success/30 hover:bg-success/10"
                 onClick={handleApproveAll}
                 disabled={reviewPendingCount === 0 || status === 'submitting'}
               >

--- a/frontend/src/components/evolution/CaseResultsGrid.tsx
+++ b/frontend/src/components/evolution/CaseResultsGrid.tsx
@@ -10,8 +10,8 @@ interface CaseResultsGridProps {
 }
 
 const TIER_STYLES: Record<string, string> = {
-  critical: 'bg-red-500/20 text-red-400',
-  normal: 'bg-blue-500/20 text-blue-400',
+  critical: 'bg-destructive/20 text-destructive',
+  normal: 'bg-info/20 text-info',
   low: 'bg-muted text-muted-foreground',
 }
 
@@ -30,7 +30,7 @@ function PassIcon({ caseId }: { caseId: string }) {
   return (
     <svg
       data-testid={`result-pass-${caseId}`}
-      className="h-5 w-5 text-emerald-400"
+      className="h-5 w-5 text-score-positive"
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={2}
@@ -51,7 +51,7 @@ function FailIcon({ caseId }: { caseId: string }) {
   return (
     <svg
       data-testid={`result-fail-${caseId}`}
-      className="h-5 w-5 text-red-400"
+      className="h-5 w-5 text-score-negative"
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={2}
@@ -116,12 +116,12 @@ function DetailPanel({
       {seedResult && (
         <div className="md:col-span-2">
           <div className="mb-2 flex items-center gap-3">
-            <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
+            <p className="text-xs font-semibold uppercase tracking-wider text-warning">
               {t('evolution.seedVsEvolved')}
             </p>
             {/* Show improvement badge */}
             {caseResult.score > seedResult.score ? (
-              <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-400">
+              <span className="rounded-full bg-score-positive/20 px-2 py-0.5 text-xs font-semibold text-score-positive">
                 Improved ({(caseResult.score - seedResult.score).toFixed(1)})
               </span>
             ) : caseResult.score === seedResult.score ? (
@@ -129,7 +129,7 @@ function DetailPanel({
                 No change
               </span>
             ) : (
-              <span className="rounded-full bg-red-500/20 px-2 py-0.5 text-xs font-semibold text-red-400">
+              <span className="rounded-full bg-score-negative/20 px-2 py-0.5 text-xs font-semibold text-score-negative">
                 Regressed ({(caseResult.score - seedResult.score).toFixed(1)})
               </span>
             )}
@@ -139,7 +139,7 @@ function DetailPanel({
             <div className="rounded border border-border/50 bg-muted p-2">
               <p className="mb-1 text-xs font-semibold text-muted-foreground">{t('evolution.seedOriginalPrompt')}</p>
               <div className="flex items-center gap-2">
-                <span className={`text-xs font-semibold ${seedResult.passed ? 'text-emerald-400' : 'text-red-400'}`}>
+                <span className={`text-xs font-semibold ${seedResult.passed ? 'text-score-positive' : 'text-score-negative'}`}>
                   {seedResult.passed ? 'PASS' : 'FAIL'}
                 </span>
                 <span className="text-xs font-mono" style={{ color: scoreColor(seedResult.score) }}>
@@ -152,7 +152,7 @@ function DetailPanel({
             <div className="rounded border border-border/50 bg-muted p-2">
               <p className="mb-1 text-xs font-semibold text-muted-foreground">{t('evolution.evolvedBestCandidate')}</p>
               <div className="flex items-center gap-2">
-                <span className={`text-xs font-semibold ${caseResult.passed ? 'text-emerald-400' : 'text-red-400'}`}>
+                <span className={`text-xs font-semibold ${caseResult.passed ? 'text-score-positive' : 'text-score-negative'}`}>
                   {caseResult.passed ? 'PASS' : 'FAIL'}
                 </span>
                 <span className="text-xs font-mono" style={{ color: scoreColor(caseResult.score) }}>
@@ -174,7 +174,7 @@ function DetailPanel({
           <div className="space-y-1">
             {caseResult.criteriaResults.map((cr, i) => (
               <div key={i} className="flex items-start gap-2 text-xs">
-                <span className={cr.passed ? 'text-emerald-400' : 'text-red-400'}>
+                <span className={cr.passed ? 'text-score-positive' : 'text-score-negative'}>
                   {cr.passed ? '\u2713' : '\u2717'}
                 </span>
                 <span className="text-foreground font-medium">{cr.criterion}:</span>
@@ -252,16 +252,16 @@ export default function CaseResultsGrid({
           <span className="text-muted-foreground">
             {t('evolution.totalCases', { count: caseResults.length })}
           </span>
-          <span className="text-emerald-500 font-medium">{t('evolution.passedCount', { count: passedCount })}</span>
-          <span className="text-red-400 font-medium">{t('evolution.failedCount', { count: failedCount })}</span>
+          <span className="text-score-positive font-medium">{t('evolution.passedCount', { count: passedCount })}</span>
+          <span className="text-score-negative font-medium">{t('evolution.failedCount', { count: failedCount })}</span>
         </div>
         <div className="flex h-1.5 overflow-hidden rounded-full bg-border/50 mt-2">
           <div
-            className="bg-emerald-500 transition-[width]"
+            className="bg-score-positive transition-[width]"
             style={{ width: `${passRate}%` }}
           />
           <div
-            className="bg-red-500 transition-[width]"
+            className="bg-score-negative transition-[width]"
             style={{ width: `${100 - passRate}%` }}
           />
         </div>
@@ -335,7 +335,7 @@ export default function CaseResultsGrid({
                       {c.score.toFixed(3)}
                     </td>
                     <td className="px-4 py-3 text-sm text-muted-foreground" title={c.reason}>
-                      <span className={`mr-1 font-semibold ${c.passed ? 'text-emerald-400' : 'text-red-400'}`}>
+                      <span className={`mr-1 font-semibold ${c.passed ? 'text-score-positive' : 'text-score-negative'}`}>
                         {c.passed ? '[PASS]' : '[FAIL]'}
                       </span>
                       {truncate(c.reason, 50)}

--- a/frontend/src/components/evolution/DiffPopover.tsx
+++ b/frontend/src/components/evolution/DiffPopover.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useMemo } from 'react'
 import type { LineageNode } from '../../types/evolution'
-import { MUTATION_COLORS, COLORS } from '../../types/evolution'
+import { mutationBg, mutationColor } from '../../types/evolution'
 import { computePairDiff, computePopoverPosition } from '../../lib/diff-utils'
 import type { DiffLine } from '../../lib/diff-utils'
 
@@ -16,16 +16,16 @@ interface DiffPopoverProps {
 
 function DiffLineRow({ line }: { line: DiffLine }) {
   if (line.type === 'hunk') {
-    return <div className="text-blue-400 mt-1 mb-0.5">{line.content}</div>
+    return <div className="text-diff-hunk mt-1 mb-0.5">{line.content}</div>
   }
   if (line.type === 'add') {
     return (
-      <div className="text-emerald-400 bg-emerald-500/5">+{line.content}</div>
+      <div className="text-diff-add bg-diff-add-bg">+{line.content}</div>
     )
   }
   if (line.type === 'del') {
     return (
-      <div className="text-red-400 bg-red-500/5 line-through opacity-70">
+      <div className="text-diff-del bg-diff-del-bg line-through opacity-70">
         -{line.content}
       </div>
     )
@@ -64,7 +64,7 @@ export function DiffPopover({
   if (!candidate || candidate.template === undefined) {
     return (
       <div
-        className="absolute pointer-events-none w-[400px] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex items-center justify-center"
+        className="absolute pointer-events-none w-[min(400px,calc(100vw-2rem))] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex items-center justify-center"
         style={{ left: `${left}px`, top: `${top}px` }}
       >
         <p className="text-muted-foreground text-sm">{t('evolution.noTemplateData')}</p>
@@ -76,7 +76,7 @@ export function DiffPopover({
   if (diffResult?.type === 'seed') {
     return (
       <div
-        className="absolute pointer-events-none w-[400px] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex flex-col overflow-hidden"
+        className="absolute pointer-events-none w-[min(400px,calc(100vw-2rem))] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex flex-col overflow-hidden"
         style={{ left: `${left}px`, top: `${top}px` }}
       >
         <div className="flex items-center gap-2 px-3 py-2 bg-muted border-b border-border shrink-0">
@@ -86,14 +86,13 @@ export function DiffPopover({
           <span
             className="text-[10px] px-1.5 py-0.5 rounded-full"
             style={{
-              backgroundColor:
-                (MUTATION_COLORS[candidate.mutationType] ?? COLORS.textMuted) + '22',
-              color: MUTATION_COLORS[candidate.mutationType] ?? COLORS.textMuted,
+              backgroundColor: mutationBg(candidate.mutationType),
+              color: mutationColor(candidate.mutationType),
             }}
           >
             {candidate.mutationType}
           </span>
-          <span className="text-emerald-400 font-bold text-xs ml-auto">
+          <span className="text-score-positive font-bold text-xs ml-auto">
             {candidate.fitnessScore.toFixed(3)}
           </span>
         </div>
@@ -110,7 +109,7 @@ export function DiffPopover({
   if (diffResult?.type === 'no-parent' || diffResult?.type === 'no-parent-template') {
     return (
       <div
-        className="absolute pointer-events-none w-[400px] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex items-center justify-center"
+        className="absolute pointer-events-none w-[min(400px,calc(100vw-2rem))] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex items-center justify-center"
         style={{ left: `${left}px`, top: `${top}px` }}
       >
         <p className="text-muted-foreground text-sm">{t('evolution.parentTemplateNotAvailable')}</p>
@@ -126,7 +125,7 @@ export function DiffPopover({
 
     return (
       <div
-        className="absolute pointer-events-none w-[400px] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex flex-col overflow-hidden"
+        className="absolute pointer-events-none w-[min(400px,calc(100vw-2rem))] h-[300px] bg-background border border-border rounded-lg shadow-xl z-30 flex flex-col overflow-hidden"
         style={{ left: `${left}px`, top: `${top}px` }}
       >
         {/* Header */}
@@ -137,14 +136,13 @@ export function DiffPopover({
           <span
             className="text-[10px] px-1.5 py-0.5 rounded-full"
             style={{
-              backgroundColor:
-                (MUTATION_COLORS[candidate.mutationType] ?? COLORS.textMuted) + '22',
-              color: MUTATION_COLORS[candidate.mutationType] ?? COLORS.textMuted,
+              backgroundColor: mutationBg(candidate.mutationType),
+              color: mutationColor(candidate.mutationType),
             }}
           >
             {candidate.mutationType}
           </span>
-          <span className="text-emerald-400 font-bold text-xs">
+          <span className="text-score-positive font-bold text-xs">
             {candidate.fitnessScore.toFixed(3)}
           </span>
           {(addCount > 0 || delCount > 0) && (

--- a/frontend/src/components/evolution/DiffViewer.tsx
+++ b/frontend/src/components/evolution/DiffViewer.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useMemo, useState } from 'react'
 import { createTwoFilesPatch } from 'diff'
 import type { LineageNode } from '../../types/evolution'
-import { COLORS, MUTATION_COLORS } from '../../types/evolution'
+import { mutationBg, mutationColor } from '../../types/evolution'
 import { traceWinningPath, detectIslandTransitions } from '../../lib/lineage-utils'
 import { parsePatchLines } from '../../lib/diff-utils'
 import type { DiffLine } from '../../lib/diff-utils'
@@ -122,7 +122,7 @@ export default function DiffViewer({
   if (nodesWithTemplates.length < 2) {
     return (
       <div className="rounded-lg border border-border bg-card/50 p-8 text-center">
-        <p style={{ color: COLORS.textMuted }}>{t('evolution.noDiffData')}</p>
+        <p className="text-muted-foreground">{t('evolution.noDiffData')}</p>
       </div>
     )
   }
@@ -140,15 +140,13 @@ export default function DiffViewer({
             <span
               className="text-xs px-2 py-0.5 rounded-full"
               style={{
-                backgroundColor:
-                  (MUTATION_COLORS[seedNode.mutationType] ?? COLORS.textMuted) + '22',
-                color:
-                  MUTATION_COLORS[seedNode.mutationType] ?? COLORS.textMuted,
+                backgroundColor: mutationBg(seedNode.mutationType),
+                color: mutationColor(seedNode.mutationType),
               }}
             >
               {seedNode.mutationType}
             </span>
-            <span className="text-emerald-400 font-bold ml-auto">
+            <span className="text-score-positive font-bold ml-auto">
               {seedNode.fitnessScore.toFixed(3)}
             </span>
           </div>
@@ -176,7 +174,7 @@ export default function DiffViewer({
         return (
           <div key={step.childId} className="space-y-2">
             {transitionMap.has(step.childId) && (
-              <div className="flex items-center gap-2 px-4 py-2 text-xs text-purple-400 bg-purple-500/10 rounded-lg border border-purple-500/20">
+              <div className="flex items-center gap-2 px-4 py-2 text-xs text-mutation-fresh bg-mutation-fresh/10 rounded-lg border border-mutation-fresh/20">
                 <span>Migrated from Island {transitionMap.get(step.childId)!.fromIsland}</span>
                 <span className="text-muted-foreground">&rarr;</span>
                 <span>Island {transitionMap.get(step.childId)!.toIsland}</span>
@@ -194,20 +192,17 @@ export default function DiffViewer({
               <span
                 className="text-xs px-2 py-0.5 rounded-full"
                 style={{
-                  backgroundColor:
-                    (MUTATION_COLORS[step.mutationType] ?? COLORS.textMuted) +
-                    '22',
-                  color:
-                    MUTATION_COLORS[step.mutationType] ?? COLORS.textMuted,
+                  backgroundColor: mutationBg(step.mutationType),
+                  color: mutationColor(step.mutationType),
                 }}
               >
                 {step.mutationType}
               </span>
-              <span className="text-emerald-400 font-bold ml-auto">
+              <span className="text-score-positive font-bold ml-auto">
                 {step.childFitness.toFixed(3)}
               </span>
               <span
-                className={`text-xs font-mono ${delta >= 0 ? 'text-emerald-400' : 'text-red-400'}`}
+                className={`text-xs font-mono ${delta >= 0 ? 'text-score-positive' : 'text-score-negative'}`}
               >
                 {delta >= 0 ? '+' : ''}
                 {delta.toFixed(3)}
@@ -222,7 +217,7 @@ export default function DiffViewer({
                     <div
                       key={j}
                       data-diff-type="hunk"
-                      className="text-blue-400 mt-2 mb-1"
+                      className="text-diff-hunk mt-2 mb-1"
                     >
                       {line.content}
                     </div>
@@ -233,7 +228,7 @@ export default function DiffViewer({
                     <div
                       key={j}
                       data-diff-type="add"
-                      className="text-emerald-400 bg-emerald-500/5"
+                      className="text-diff-add bg-diff-add-bg"
                     >
                       +{line.content}
                     </div>
@@ -244,7 +239,7 @@ export default function DiffViewer({
                     <div
                       key={j}
                       data-diff-type="del"
-                      className="text-red-400 bg-red-500/5 line-through opacity-70"
+                      className="text-diff-del bg-diff-del-bg line-through opacity-70"
                     >
                       -{line.content}
                     </div>

--- a/frontend/src/components/evolution/EvolutionDashboard.tsx
+++ b/frontend/src/components/evolution/EvolutionDashboard.tsx
@@ -26,21 +26,21 @@ function StatusBadge({ status }: { status: EvolutionStatus }) {
   switch (status) {
     case 'connecting':
       return (
-        <Badge className="bg-blue-500/10 text-blue-400 border-blue-500/20">
-          <span className="h-2 w-2 rounded-full bg-blue-400 animate-pulse mr-1.5" />
+        <Badge className="bg-info/10 text-info border-info/20">
+          <span className="h-2 w-2 rounded-full bg-info animate-pulse mr-1.5" />
           {t('evolution.connecting')}
         </Badge>
       )
     case 'running':
       return (
-        <Badge className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20">
-          <span className="h-2 w-2 rounded-full bg-emerald-400 animate-pulse mr-1.5" />
+        <Badge className="bg-success/10 text-success border-success/20">
+          <span className="h-2 w-2 rounded-full bg-success animate-pulse mr-1.5" />
           {t('evolution.live')}
         </Badge>
       )
     case 'complete':
       return (
-        <Badge className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20">
+        <Badge className="bg-success/10 text-success border-success/20">
           {t('evolution.complete')}
         </Badge>
       )
@@ -77,10 +77,10 @@ function CompactSummary({ data }: { data: SummaryData }) {
   return (
     <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 text-sm">
       <span className="font-semibold text-foreground">
-        Best: <span className="text-emerald-500 tabular-nums">{data.bestFitness?.toFixed(2) ?? '—'}</span>
+        Best: <span className="text-score-positive tabular-nums">{data.bestFitness?.toFixed(2) ?? '—'}</span>
       </span>
       {data.improvementDelta != null && data.improvementDelta > 0 && (
-        <span className="text-emerald-500 font-medium">+{data.improvementDelta.toFixed(1)} improvement</span>
+        <span className="text-score-positive font-medium">+{data.improvementDelta.toFixed(1)} improvement</span>
       )}
       <span className="text-muted-foreground">Seed: {data.seedFitness?.toFixed(2) ?? '—'}</span>
       <span className="text-muted-foreground">
@@ -116,11 +116,11 @@ function OverviewContent({
       <CompactSummary data={state.summary} />
 
       {/* Charts row */}
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 items-stretch">
-        <div className="lg:col-span-3">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6 items-stretch">
+        <div className="md:col-span-2 lg:col-span-3">
           <FitnessChart data={state.generations} isLive={state.status === 'running'} />
         </div>
-        <div className="lg:col-span-2 flex">
+        <div className="md:col-span-2 lg:col-span-2 flex">
           <IslandsSummary
             candidates={state.candidates}
             migrations={state.migrations}
@@ -415,10 +415,10 @@ export default function EvolutionDashboard({ runId }: EvolutionDashboardProps) {
               {/* Right: CTA */}
               <div className="ml-auto flex items-center gap-2">
                 {acceptError && (
-                  <span className="text-red-400 text-xs">{acceptError}</span>
+                  <span className="text-score-negative text-xs">{acceptError}</span>
                 )}
                 {acceptedVersion !== null && (
-                  <Badge className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20 text-xs">
+                  <Badge className="bg-success/10 text-success border-success/20 text-xs">
                     v{acceptedVersion}
                   </Badge>
                 )}

--- a/frontend/src/components/evolution/FitnessChart.tsx
+++ b/frontend/src/components/evolution/FitnessChart.tsx
@@ -12,7 +12,7 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import type { GenerationData } from '../../types/evolution'
-import { COLORS } from '../../types/evolution'
+import { MUTATION_COLORS, SCORE_POSITIVE } from '../../types/evolution'
 
 interface FitnessChartProps {
   data: GenerationData[]
@@ -65,8 +65,8 @@ export default function FitnessChart({ data, isLive = false }: FitnessChartProps
             <>
               <div className="flex items-center gap-2">
                 <span className="relative flex h-3 w-3">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-3 w-3 bg-primary"></span>
                 </span>
                 <p className="text-muted-foreground">{t('evolution.evaluatingFirstGeneration')}</p>
               </div>
@@ -79,31 +79,31 @@ export default function FitnessChart({ data, isLive = false }: FitnessChartProps
       ) : (
         <ResponsiveContainer width="100%" height={400}>
           <LineChart data={cleanData}>
-            <CartesianGrid strokeDasharray="3 3" stroke={COLORS.border} />
-            <XAxis dataKey="label" stroke={COLORS.textSecondary} />
-            <YAxis yAxisId="left" domain={fitnessDomain} stroke={COLORS.textSecondary} tickFormatter={(v: number) => v.toFixed(1)} />
-            <YAxis yAxisId="normalized" orientation="right" domain={[normalizedMin, normalizedMax]} stroke={COLORS.purple} tickFormatter={(v: number) => v.toFixed(1)} />
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+            <XAxis dataKey="label" stroke="var(--color-muted-foreground)" />
+            <YAxis yAxisId="left" domain={fitnessDomain} stroke="var(--color-muted-foreground)" tickFormatter={(v: number) => v.toFixed(1)} />
+            <YAxis yAxisId="normalized" orientation="right" domain={[normalizedMin, normalizedMax]} stroke={MUTATION_COLORS.fresh} tickFormatter={(v: number) => v.toFixed(1)} />
             <ReferenceLine
               yAxisId="left"
               y={0}
-              stroke="#22c55e"
+              stroke={SCORE_POSITIVE}
               strokeDasharray="6 3"
               strokeWidth={1.5}
               label={{
                 value: 'Perfect (0)',
                 position: 'right',
-                fill: '#22c55e',
+                fill: SCORE_POSITIVE,
                 fontSize: 11,
               }}
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: COLORS.cardBg,
-                border: `1px solid ${COLORS.border}`,
-                color: COLORS.textPrimary,
+                backgroundColor: 'var(--color-card)',
+                border: '1px solid var(--color-border)',
+                color: 'var(--color-foreground)',
                 borderRadius: '0.5rem',
               }}
-              labelStyle={{ color: COLORS.textPrimary }}
+              labelStyle={{ color: 'var(--color-foreground)' }}
               formatter={(value) => typeof value === 'number' ? value.toFixed(2) : String(value ?? '')}
             />
             <Legend />
@@ -111,9 +111,9 @@ export default function FitnessChart({ data, isLive = false }: FitnessChartProps
               yAxisId="left"
               type="monotone"
               dataKey="bestFitness"
-              stroke={COLORS.green}
+              stroke={MUTATION_COLORS.rcc}
               strokeWidth={3}
-              dot={{ fill: COLORS.green }}
+              dot={{ fill: MUTATION_COLORS.rcc }}
               name={t('evolution.bestFitness')}
               isAnimationActive={false}
               connectNulls={true}
@@ -122,9 +122,9 @@ export default function FitnessChart({ data, isLive = false }: FitnessChartProps
               yAxisId="left"
               type="monotone"
               dataKey="avgFitness"
-              stroke={COLORS.blue}
+              stroke={MUTATION_COLORS.migrated}
               strokeWidth={3}
-              dot={{ fill: COLORS.blue }}
+              dot={{ fill: MUTATION_COLORS.migrated }}
               name={t('evolution.avgFitness')}
               isAnimationActive={false}
               connectNulls={true}
@@ -134,10 +134,10 @@ export default function FitnessChart({ data, isLive = false }: FitnessChartProps
                 yAxisId="normalized"
                 type="monotone"
                 dataKey="bestNormalized"
-                stroke={COLORS.purple}
+                stroke={MUTATION_COLORS.fresh}
                 strokeWidth={2}
                 strokeDasharray="5 3"
-                dot={{ fill: COLORS.purple }}
+                dot={{ fill: MUTATION_COLORS.fresh }}
                 name={t('evolution.bestNorm')}
                 isAnimationActive={false}
                 connectNulls={true}

--- a/frontend/src/components/evolution/FitnessLegend.tsx
+++ b/frontend/src/components/evolution/FitnessLegend.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from 'react-i18next'
+import { SCORE_POSITIVE, SCORE_NEGATIVE, SCORE_NEUTRAL, MUTATION_COLORS } from '../../types/evolution'
+
 interface FitnessLegendProps {
   x: number
   y: number
@@ -18,22 +20,22 @@ export function FitnessLegend({ x, y, gradientId = 'fitness-gradient', minValue 
     <g transform={`translate(${x}, ${y})`}>
       <defs>
         <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="#ef4444" />
-          <stop offset="50%" stopColor="#f59e0b" />
-          <stop offset="100%" stopColor="#22c55e" />
+          <stop offset="0%" stopColor={SCORE_NEGATIVE} />
+          <stop offset="50%" stopColor={MUTATION_COLORS.structural} />
+          <stop offset="100%" stopColor={SCORE_POSITIVE} />
         </linearGradient>
       </defs>
       {/* Title */}
-      <text x={0} y={0} fontSize={10} fill="#94a3b8">
+      <text x={0} y={0} fontSize={10} fill={SCORE_NEUTRAL}>
         {t('evolution.fitness')}
       </text>
       {/* Gradient bar */}
       <rect x={0} y={4} width={80} height={8} rx={2} fill={`url(#${gradientId})`} />
       {/* Labels */}
-      <text x={0} y={22} fontSize={9} fill="#94a3b8">
+      <text x={0} y={22} fontSize={9} fill={SCORE_NEUTRAL}>
         {minValue}
       </text>
-      <text x={80} y={22} fontSize={9} fill="#94a3b8" textAnchor="end">
+      <text x={80} y={22} fontSize={9} fill={SCORE_NEUTRAL} textAnchor="end">
         0
       </text>
     </g>

--- a/frontend/src/components/evolution/GenerationTable.tsx
+++ b/frontend/src/components/evolution/GenerationTable.tsx
@@ -10,7 +10,7 @@ interface GenerationTableProps {
 export default function GenerationTable({ data, isLive = false }: GenerationTableProps) {
   const { t } = useTranslation()
   return (
-    <div className="rounded-lg border border-border bg-card overflow-hidden">
+    <div className="rounded-lg border border-border bg-card overflow-hidden overflow-x-auto">
       <div className="px-4 py-3 border-b border-border">
         <h3 className="text-sm font-semibold text-foreground">{t('evolution.generationDetails')}</h3>
       </div>

--- a/frontend/src/components/evolution/HyperparameterDisplay.tsx
+++ b/frontend/src/components/evolution/HyperparameterDisplay.tsx
@@ -157,11 +157,11 @@ function ParamRow({ label, value, override, t }: { label: string; value: unknown
     <div className="flex items-center justify-between gap-2 text-sm">
       <span className="text-muted-foreground truncate">{label}</span>
       <span className="flex items-center gap-1.5 shrink-0">
-        <span className={override ? 'font-mono text-amber-400' : 'font-mono text-foreground'}>
+        <span className={override ? 'font-mono text-warning' : 'font-mono text-foreground'}>
           {String(value)}
         </span>
         {override && (
-          <Badge variant="outline" className="text-amber-400 border-amber-400/30 px-1.5 py-0 text-[10px]">
+          <Badge variant="outline" className="text-warning border-warning/30 px-1.5 py-0 text-[10px]">
             {t('evolution.override')}
           </Badge>
         )}
@@ -215,11 +215,11 @@ export default function HyperparameterDisplay({ hyperparameters, modelInfo }: Hy
         {keyEntries.map(({ key, label, value, override }) => (
           <span key={key} className="inline-flex items-center gap-1 text-xs text-muted-foreground">
             {label}
-            <span className={override ? 'font-mono text-amber-400' : 'font-mono text-foreground'}>
+            <span className={override ? 'font-mono text-warning' : 'font-mono text-foreground'}>
               {String(value)}
             </span>
             {override && (
-              <Badge variant="outline" className="text-amber-400 border-amber-400/30 px-1 py-0 text-[10px] leading-tight">
+              <Badge variant="outline" className="text-warning border-warning/30 px-1 py-0 text-[10px] leading-tight">
                 {t('evolution.override')}
               </Badge>
             )}

--- a/frontend/src/components/evolution/IslandsSummary.tsx
+++ b/frontend/src/components/evolution/IslandsSummary.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { CandidateData, MigrationData, EvolutionStatus } from '../../types/evolution'
-import { MUTATION_COLORS } from '../../types/evolution'
+import { mutationColor } from '../../types/evolution'
 import { scoreColor } from '../../lib/scoring'
 
 interface IslandsSummaryProps {
@@ -86,7 +86,7 @@ export default function IslandsSummary({ candidates, migrations, islandCount, st
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-2 flex-1 content-start">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 flex-1 content-start">
         {islands.map((island) => (
           <div
             key={island.island}
@@ -115,7 +115,7 @@ export default function IslandsSummary({ candidates, migrations, islandCount, st
                       {island.bestFitness.toFixed(2)}
                     </span>
                     {island.improvement != null && island.improvement > 0 && (
-                      <span className="text-xs text-emerald-500 font-semibold">
+                      <span className="text-xs text-score-positive font-semibold">
                         +{island.improvement.toFixed(1)}
                       </span>
                     )}
@@ -141,7 +141,7 @@ export default function IslandsSummary({ candidates, migrations, islandCount, st
                         title={`${type}: ${count}`}
                         style={{
                           width: `${(count / island.candidateCount) * 100}%`,
-                          backgroundColor: MUTATION_COLORS[type] ?? '#64748b',
+                          backgroundColor: mutationColor(type),
                         }}
                       />
                     ))}
@@ -149,7 +149,7 @@ export default function IslandsSummary({ candidates, migrations, islandCount, st
                   <div className="flex flex-wrap gap-x-2 gap-y-0.5">
                     {Array.from(island.mutationBreakdown.entries()).map(([type, count]) => (
                       <span key={type} className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
-                        <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ backgroundColor: MUTATION_COLORS[type] ?? '#64748b' }} />
+                        <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ backgroundColor: mutationColor(type) }} />
                         {type.replace('_', ' ')} {count}
                       </span>
                     ))}

--- a/frontend/src/components/evolution/LineageGraph.tsx
+++ b/frontend/src/components/evolution/LineageGraph.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useRef, useCallback } from 'react'
 import type { LineageNode } from '../../types/evolution'
-import { MUTATION_COLORS, COLORS } from '../../types/evolution'
+import { MUTATION_COLORS, mutationBg, mutationColor, SCORE_POSITIVE } from '../../types/evolution'
 import { fitnessColor, REJECTED_OPACITY, ACTIVE_OPACITY, getDotRadius } from '../../lib/scoring'
 import { traceWinningPath, deduplicateEvents } from '../../lib/lineage-utils'
 import { computePairDiff } from '../../lib/diff-utils'
@@ -42,13 +42,13 @@ const LABEL_WIDTH = 56
 
 function DiffLineRow({ line }: { line: DiffLine }) {
   if (line.type === 'hunk') {
-    return <div className="text-blue-400 mt-1 mb-0.5">{line.content}</div>
+    return <div className="text-diff-hunk mt-1 mb-0.5">{line.content}</div>
   }
   if (line.type === 'add') {
-    return <div className="text-emerald-400 bg-emerald-500/5">+{line.content}</div>
+    return <div className="text-diff-add bg-diff-add-bg">+{line.content}</div>
   }
   if (line.type === 'del') {
-    return <div className="text-red-400 bg-red-500/5 line-through opacity-70">-{line.content}</div>
+    return <div className="text-diff-del bg-diff-del-bg line-through opacity-70">-{line.content}</div>
   }
   return <div className="text-muted-foreground"> {line.content}</div>
 }
@@ -87,7 +87,7 @@ export default function LineageGraph({ lineageEvents, bestCandidateId }: Lineage
         if (depedIdx.has(pid)) maxParentDepth = Math.max(maxParentDepth, computeDepth(pid, visited))
       }
       const parent = e.parentIds.length > 0 ? depedIdx.get(e.parentIds[0]) : null
-      const isClone = parent && e.template !== undefined && parent.template !== undefined
+      const isClone = parent && e.template != null && parent.template != null
         && e.template.trim() === parent.template.trim()
       const d = isClone ? maxParentDepth : maxParentDepth + 1
       depthCache.set(id, d)
@@ -260,13 +260,13 @@ export default function LineageGraph({ lineageEvents, bestCandidateId }: Lineage
           </span>
         ))}
         <span className="ml-auto inline-flex items-center gap-1.5">
-          <span className="inline-block w-4 h-0.5 bg-emerald-500 rounded" />
+          <span className="inline-block w-4 h-0.5 bg-score-positive rounded" />
           winning path
         </span>
       </div>
 
       {/* Graph area (scrollable) */}
-      <div ref={containerRef} className="relative overflow-auto" style={{ maxHeight: 450 }}>
+      <div ref={containerRef} className="relative overflow-auto max-h-[min(450px,60vh)]">
         <svg
           width={svgWidth}
           height={svgHeight}
@@ -295,7 +295,7 @@ export default function LineageGraph({ lineageEvents, bestCandidateId }: Lineage
             const path = `M ${src.x} ${src.y} C ${src.x} ${midY}, ${tgt.x} ${midY}, ${tgt.x} ${tgt.y}`
             return (
               <path key={`edge-${i}`} d={path} fill="none"
-                stroke={edge.isMigration ? '#8b5cf6' : 'currentColor'}
+                stroke={edge.isMigration ? MUTATION_COLORS.fresh : 'currentColor'}
                 className={edge.isMigration ? '' : 'text-border'}
                 strokeWidth={edge.isMigration ? 1.5 : 1}
                 strokeDasharray={edge.isMigration ? '4 3' : undefined}
@@ -312,15 +312,15 @@ export default function LineageGraph({ lineageEvents, bestCandidateId }: Lineage
             const path = `M ${src.x} ${src.y} C ${src.x} ${midY}, ${tgt.x} ${midY}, ${tgt.x} ${tgt.y}`
             return (
               <g key={`winning-${i}`}>
-                <path d={path} fill="none" stroke="#22c55e" strokeWidth={6} opacity={0.15} strokeLinecap="round" />
-                <path d={path} fill="none" stroke="#22c55e" strokeWidth={2.5} opacity={0.9} strokeLinecap="round" />
+                <path d={path} fill="none" stroke={SCORE_POSITIVE} strokeWidth={6} opacity={0.15} strokeLinecap="round" />
+                <path d={path} fill="none" stroke={SCORE_POSITIVE} strokeWidth={2.5} opacity={0.9} strokeLinecap="round" />
               </g>
             )
           })}
 
           {/* Nodes */}
           {nodes.map((node) => {
-            const color = MUTATION_COLORS[node.mutationType] ?? '#64748b'
+            const color = mutationColor(node.mutationType)
             const fitColor = fitnessColor(node.fitnessScore) as string
             const opacity = node.rejected ? REJECTED_OPACITY : ACTIVE_OPACITY
             const r = node.radius
@@ -329,10 +329,10 @@ export default function LineageGraph({ lineageEvents, bestCandidateId }: Lineage
             return (
               <g key={node.id}>
                 {node.isWinning && (
-                  <circle cx={node.x} cy={node.y} r={r + 5} fill="none" stroke="#22c55e" strokeWidth={2} opacity={0.3} />
+                  <circle cx={node.x} cy={node.y} r={r + 5} fill="none" stroke={SCORE_POSITIVE} strokeWidth={2} opacity={0.3} />
                 )}
                 {node.isBest && (
-                  <circle cx={node.x} cy={node.y} r={r + 8} fill="none" stroke="#22c55e" strokeWidth={2.5} strokeDasharray="3 2" opacity={0.6} />
+                  <circle cx={node.x} cy={node.y} r={r + 8} fill="none" stroke={SCORE_POSITIVE} strokeWidth={2.5} strokeDasharray="3 2" opacity={0.6} />
                 )}
                 {isSelected && (
                   <circle cx={node.x} cy={node.y} r={r + 6} fill="none" stroke="currentColor" className="text-foreground" strokeWidth={2} opacity={0.8} />
@@ -356,13 +356,13 @@ export default function LineageGraph({ lineageEvents, bestCandidateId }: Lineage
             style={{ left: tooltip.x + 12, top: tooltip.y - 10 }}>
             <div className="font-mono font-bold">{tooltip.node.id.slice(0, 8)}</div>
             <div className="flex items-center gap-2 mt-1">
-              <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: MUTATION_COLORS[tooltip.node.mutationType] ?? '#64748b' }} />
+              <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: mutationColor(tooltip.node.mutationType) }} />
               <span>{tooltip.node.mutationType}</span>
             </div>
             <div className="mt-1">Fitness: <span className="font-mono font-semibold">{tooltip.node.fitnessScore.toFixed(3)}</span></div>
             <div>Gen {tooltip.node.generation} | Island {tooltip.node.island}</div>
             {tooltip.node.rejected && <div className="text-destructive mt-0.5">Rejected</div>}
-            {tooltip.node.isBest && <div className="text-emerald-500 font-semibold mt-0.5">Best candidate</div>}
+            {tooltip.node.isBest && <div className="text-score-positive font-semibold mt-0.5">Best candidate</div>}
             <div className="text-muted-foreground mt-1 border-t border-border pt-1">Click to view diff</div>
           </div>
         )}
@@ -378,12 +378,12 @@ export default function LineageGraph({ lineageEvents, bestCandidateId }: Lineage
             </span>
             <span className="text-[10px] px-1.5 py-0.5 rounded-full"
               style={{
-                backgroundColor: (MUTATION_COLORS[selectedDiff.candidate.mutationType] ?? COLORS.textMuted) + '22',
-                color: MUTATION_COLORS[selectedDiff.candidate.mutationType] ?? COLORS.textMuted,
+                backgroundColor: mutationBg(selectedDiff.candidate.mutationType),
+                color: mutationColor(selectedDiff.candidate.mutationType),
               }}>
               {selectedDiff.candidate.mutationType}
             </span>
-            <span className="text-emerald-400 font-bold text-xs">
+            <span className="text-score-positive font-bold text-xs">
               {selectedDiff.candidate.fitnessScore.toFixed(3)}
             </span>
             {selectedDiff.type === 'diff' && (

--- a/frontend/src/components/evolution/MutationStats.tsx
+++ b/frontend/src/components/evolution/MutationStats.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useMemo } from 'react'
 import type { LineageNode, MutationStat } from '../../types/evolution'
-import { MUTATION_COLORS } from '../../types/evolution'
+import { mutationBg, mutationColor, SCORE_POSITIVE, SCORE_NEGATIVE, SCORE_NEUTRAL } from '../../types/evolution'
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 
 interface MutationStatsProps {
@@ -89,7 +89,7 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
                 title={`${mtype}: ${s.count} (${pct.toFixed(1)}%)`}
                 style={{
                   width: `${pct}%`,
-                  backgroundColor: MUTATION_COLORS[mtype] ?? '#64748b',
+                  backgroundColor: mutationColor(mtype),
                 }}
               />
             )
@@ -101,7 +101,7 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
               <span
                 className="inline-block h-2 w-2 rounded-full"
                 style={{
-                  backgroundColor: MUTATION_COLORS[mtype] ?? '#64748b',
+                  backgroundColor: mutationColor(mtype),
                 }}
               />
               {mtype}: {s.count}
@@ -127,10 +127,10 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
               const rate = s.count > 0 ? (s.improved / s.count) * 100 : 0
               const deltaColor =
                 s.avgDelta > 0
-                  ? '#22c55e'
+                  ? SCORE_POSITIVE
                   : s.avgDelta < 0
-                    ? '#ef4444'
-                    : '#94a3b8'
+                    ? SCORE_NEGATIVE
+                    : SCORE_NEUTRAL
 
               return (
                 <TableRow key={mtype}>
@@ -138,8 +138,8 @@ export default function MutationStats({ lineageEvents }: MutationStatsProps) {
                     <span
                       className="inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold"
                       style={{
-                        background: `${MUTATION_COLORS[mtype] ?? '#64748b'}22`,
-                        color: MUTATION_COLORS[mtype] ?? '#64748b',
+                        background: mutationBg(mtype),
+                        color: mutationColor(mtype),
                       }}
                     >
                       {mtype}

--- a/frontend/src/components/evolution/RunConfigForm.tsx
+++ b/frontend/src/components/evolution/RunConfigForm.tsx
@@ -176,14 +176,14 @@ export default function RunConfigForm({ promptId: propPromptId, onRunStarted }: 
 
   if (successResult) {
     return (
-      <Card className="border-emerald-500/30">
+      <Card className="border-success/30">
         <CardContent className="pt-6">
-          <h3 className="text-lg font-semibold text-emerald-400 mb-2">{t('evolution.evolutionStarted')}</h3>
+          <h3 className="text-lg font-semibold text-success mb-2">{t('evolution.evolutionStarted')}</h3>
           <p className="text-foreground mb-1">
-            {t('evolution.runIdLabel')} <span className="font-mono text-emerald-400" data-testid="run-id">{successResult.run_id}</span>
+            {t('evolution.runIdLabel')} <span className="font-mono text-success" data-testid="run-id">{successResult.run_id}</span>
           </p>
           <p className="text-muted-foreground mb-4">
-            {t('evolution.statusLabel')} <span className="text-emerald-400">{successResult.status}</span>
+            {t('evolution.statusLabel')} <span className="text-success">{successResult.status}</span>
           </p>
           <div className="flex gap-3">
             <Button variant="secondary" asChild>

--- a/frontend/src/components/evolution/SummaryCards.tsx
+++ b/frontend/src/components/evolution/SummaryCards.tsx
@@ -36,8 +36,8 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
     return labels[r] ?? r.replace(/_/g, ' ')
   })()
 
-  const stopReasonColor = data.terminationReason === 'perfect_fitness' ? 'text-emerald-400'
-    : data.terminationReason === 'error' ? 'text-red-400'
+  const stopReasonColor = data.terminationReason === 'perfect_fitness' ? 'text-score-positive'
+    : data.terminationReason === 'error' ? 'text-score-negative'
     : 'text-foreground'
 
   // Primary cards: the headline metrics
@@ -47,7 +47,7 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
       value: data.bestFitness != null
         ? `${data.bestFitness.toFixed(2)}${data.bestNormalized != null && !isNaN(data.bestNormalized) ? ` (${data.bestNormalized.toFixed(2)} norm)` : ''}${progressPct !== null ? ` ${progressPct}%` : ''}`
         : '\u2014',
-      colorClass: 'text-emerald-400',
+      colorClass: 'text-score-positive',
       icon: Trophy,
       primary: true,
     },
@@ -56,7 +56,7 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
       value: data.seedFitness != null && data.bestFitness != null && data.improvementDelta != null
         ? `+${data.improvementDelta.toFixed(2)}`
         : '\u2014',
-      colorClass: 'text-blue-400',
+      colorClass: 'text-info',
       icon: TrendingUp,
       primary: true,
     },
@@ -67,7 +67,7 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
     {
       label: t('evolution.seedFitness'),
       value: data.seedFitness != null ? data.seedFitness.toFixed(2) : '\u2014',
-      colorClass: 'text-amber-400',
+      colorClass: 'text-warning',
       icon: Target,
     },
     {
@@ -79,13 +79,13 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
     {
       label: t('evolution.lineageEvents'),
       value: String(data.lineageEventCount),
-      colorClass: 'text-blue-400',
+      colorClass: 'text-info',
       icon: GitBranch,
     },
     {
       label: t('evolution.totalCost'),
       value: `$${(data.totalCostUsd ?? 0).toFixed(4)}`,
-      colorClass: 'text-amber-400',
+      colorClass: 'text-warning',
       icon: DollarSign,
     },
   ]

--- a/frontend/src/components/history/RunHistoryTable.tsx
+++ b/frontend/src/components/history/RunHistoryTable.tsx
@@ -22,13 +22,13 @@ function StatusBadge({ status }: { status: string }) {
   switch (status) {
     case 'completed':
       return (
-        <Badge className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20">
+        <Badge className="bg-success/10 text-success border-success/20">
           {label}
         </Badge>
       )
     case 'running':
       return (
-        <Badge className="bg-blue-500/10 text-blue-400 border-blue-500/20">
+        <Badge className="bg-info/10 text-info border-info/20">
           {label}
         </Badge>
       )
@@ -170,7 +170,7 @@ export default function RunHistoryTable({ promptId: propPromptId }: RunHistoryTa
               onClick={() => {
                 navigate(`/prompts/${run.prompt_id}/evolution?run=${run.run_id}`)
               }}
-              className="flex items-center gap-3 rounded-lg border border-blue-500/30 bg-blue-500/5 px-4 py-3 cursor-pointer hover:bg-blue-500/10 transition-colors"
+              className="flex items-center gap-3 rounded-lg border border-info/30 bg-info/5 px-4 py-3 cursor-pointer hover:bg-info/10 transition-colors"
             >
               <StatusBadge status={run.status} />
               <span className="font-mono text-xs text-foreground">{run.run_id.slice(0, 8)}</span>

--- a/frontend/src/components/prompts/PromptDetail.tsx
+++ b/frontend/src/components/prompts/PromptDetail.tsx
@@ -200,7 +200,7 @@ function VariableSchemaRow({ varDef }: { varDef: VariableDefinition }) {
         {varDef.is_anchor && (
           <Badge
             variant="outline"
-            className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30 text-xs"
+            className="bg-success/20 text-success border-success/30 text-xs"
           >
             {t('prompts.anchor')}
           </Badge>
@@ -225,7 +225,7 @@ function VariableSchemaRow({ varDef }: { varDef: VariableDefinition }) {
               {subField.is_anchor && (
                 <Badge
                   variant="outline"
-                  className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30 text-xs"
+                  className="bg-success/20 text-success border-success/30 text-xs"
                 >
                   {t('prompts.anchor')}
                 </Badge>
@@ -591,7 +591,7 @@ function ToolCard({ tool, index }: { tool: Tool; index: number }) {
                 {required.has(paramName) && (
                   <Badge
                     variant="outline"
-                    className="text-xs py-0 text-amber-400 border-amber-500/30 bg-amber-500/10"
+                    className="text-xs py-0 text-warning border-warning/30 bg-warning/10"
                   >
                     {t('prompts.required')}
                   </Badge>

--- a/frontend/src/components/prompts/TemplateEditor.tsx
+++ b/frontend/src/components/prompts/TemplateEditor.tsx
@@ -81,10 +81,10 @@ export default function TemplateEditor({ promptId, initialTemplate, onSaved }: T
           {t('common.cancel')}
         </button>
         {saveStatus === 'saved' && (
-          <span className="text-sm text-emerald-400">{t('prompts.saved')}</span>
+          <span className="text-sm text-success">{t('prompts.saved')}</span>
         )}
         {saveStatus === 'error' && (
-          <span className="text-sm text-red-400">{t('prompts.failedToSaveTemplate')}</span>
+          <span className="text-sm text-destructive">{t('prompts.failedToSaveTemplate')}</span>
         )}
       </div>
     </div>

--- a/frontend/src/components/prompts/VersionDiffViewer.tsx
+++ b/frontend/src/components/prompts/VersionDiffViewer.tsx
@@ -53,7 +53,7 @@ export default function VersionDiffViewer({
                   <div
                     key={i}
                     data-diff-type="hunk"
-                    className="text-blue-400 mt-2 mb-1"
+                    className="text-diff-hunk mt-2 mb-1"
                   >
                     {line.content}
                   </div>
@@ -64,7 +64,7 @@ export default function VersionDiffViewer({
                   <div
                     key={i}
                     data-diff-type="add"
-                    className="text-emerald-400 bg-emerald-500/5"
+                    className="text-diff-add bg-diff-add-bg"
                   >
                     +{line.content}
                   </div>
@@ -75,7 +75,7 @@ export default function VersionDiffViewer({
                   <div
                     key={i}
                     data-diff-type="del"
-                    className="text-red-400 bg-red-500/5"
+                    className="text-diff-del bg-diff-del-bg"
                   >
                     -{line.content}
                   </div>

--- a/frontend/src/components/prompts/VersionHistory.tsx
+++ b/frontend/src/components/prompts/VersionHistory.tsx
@@ -125,7 +125,7 @@ export default function VersionHistory({ promptId }: VersionHistoryProps) {
                 type="checkbox"
                 checked={selectedForDiff.has(ver.version)}
                 onChange={() => toggleDiffSelection(ver.version)}
-                className="h-4 w-4 rounded border-border bg-secondary text-emerald-500 focus:ring-emerald-500/50"
+                className="h-4 w-4 rounded border-border bg-secondary text-success focus:ring-success/50"
                 title="Select for diff comparison"
               />
             )}
@@ -137,7 +137,7 @@ export default function VersionHistory({ promptId }: VersionHistoryProps) {
 
             {/* Active badge */}
             {ver.is_active && (
-              <Badge className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20">
+              <Badge className="bg-success/10 text-success border-success/20">
                 Active
               </Badge>
             )}
@@ -161,7 +161,7 @@ export default function VersionHistory({ promptId }: VersionHistoryProps) {
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="text-xs text-emerald-400 hover:text-emerald-300"
+                  className="text-xs text-success hover:text-success/80"
                   onClick={() => activateMutation.mutate(ver.version)}
                   disabled={activateMutation.isPending}
                 >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -43,6 +43,25 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --font-sans: 'DM Sans', system-ui, sans-serif;
+
+  /* Evolution semantic colors */
+  --color-diff-add: var(--diff-add);
+  --color-diff-add-bg: var(--diff-add-bg);
+  --color-diff-del: var(--diff-del);
+  --color-diff-del-bg: var(--diff-del-bg);
+  --color-diff-hunk: var(--diff-hunk);
+  --color-score-positive: var(--score-positive);
+  --color-score-negative: var(--score-negative);
+  --color-score-neutral: var(--score-neutral);
+  --color-mutation-rcc: var(--mutation-rcc);
+  --color-mutation-structural: var(--mutation-structural);
+  --color-mutation-fresh: var(--mutation-fresh);
+  --color-mutation-migrated: var(--mutation-migrated);
+  --color-mutation-reset: var(--mutation-reset);
+  --color-mutation-seed: var(--mutation-seed);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-info: var(--info);
 }
 
 /*
@@ -85,6 +104,31 @@
   --sidebar-accent-foreground: oklch(0.25 0.02 155);
   --sidebar-border: oklch(0.15 0.015 155 / 10%);
   --sidebar-ring: oklch(0.6 0.19 155);
+
+  /* Diff colors (darker shades for light backgrounds) */
+  --diff-add: oklch(0.5 0.14 155);
+  --diff-add-bg: oklch(0.5 0.14 155 / 8%);
+  --diff-del: oklch(0.55 0.18 25);
+  --diff-del-bg: oklch(0.55 0.18 25 / 8%);
+  --diff-hunk: oklch(0.55 0.12 250);
+
+  /* Score feedback */
+  --score-positive: #22c55e;
+  --score-negative: #ef4444;
+  --score-neutral: #94a3b8;
+
+  /* Semantic state colors */
+  --success: oklch(0.6 0.19 155);
+  --warning: #f59e0b;
+  --info: #3b82f6;
+
+  /* Mutation type colors (categorical, theme-independent) */
+  --mutation-rcc: #22c55e;
+  --mutation-structural: #f59e0b;
+  --mutation-fresh: #8b5cf6;
+  --mutation-migrated: #3b82f6;
+  --mutation-reset: #ef4444;
+  --mutation-seed: #94a3b8;
 }
 
 /* ── Dark mode ── */
@@ -120,6 +164,18 @@
   --sidebar-accent-foreground: oklch(0.96 0.006 155);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.65 0.19 155);
+
+  /* Diff colors (lighter shades for dark backgrounds) */
+  --diff-add: oklch(0.75 0.14 155);
+  --diff-add-bg: oklch(0.75 0.14 155 / 5%);
+  --diff-del: oklch(0.72 0.15 25);
+  --diff-del-bg: oklch(0.72 0.15 25 / 5%);
+  --diff-hunk: oklch(0.72 0.12 250);
+
+  /* Semantic state colors (dark mode variants) */
+  --success: oklch(0.65 0.19 155);
+  --warning: #f59e0b;
+  --info: #60a5fa;
 }
 
 @layer base {

--- a/frontend/src/pages/PromptConfigPage.tsx
+++ b/frontend/src/pages/PromptConfigPage.tsx
@@ -89,10 +89,10 @@ const CONFIG_PRESETS: Record<string, Preset> = {
 // --- Role icon mapping (text comes from t()) ---
 
 const ROLE_ICONS: Record<'meta' | 'target' | 'judge' | 'tool_mocker', React.ReactNode> = {
-  meta: <Zap className="h-4 w-4 text-amber-500" />,
-  target: <Target className="h-4 w-4 text-blue-500" />,
-  judge: <Scale className="h-4 w-4 text-purple-500" />,
-  tool_mocker: <Wrench className="h-4 w-4 text-green-500" />,
+  meta: <Zap className="h-4 w-4 text-warning" />,
+  target: <Target className="h-4 w-4 text-info" />,
+  judge: <Scale className="h-4 w-4 text-mutation-fresh" />,
+  tool_mocker: <Wrench className="h-4 w-4 text-success" />,
 }
 
 const ROLE_DEFAULT_FOR: Record<string, string> = {
@@ -557,7 +557,7 @@ export default function PromptConfigPage() {
           <div
             className={`px-4 py-3 text-sm border-t ${
               statusBanner.type === 'success'
-                ? 'bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20'
+                ? 'bg-success/10 text-success border-success/20'
                 : 'bg-destructive/10 text-destructive border-destructive/20'
             }`}
           >
@@ -1047,7 +1047,7 @@ function FormatGuideToolSection({
       <div className="flex items-center gap-2">
         <span className="text-sm font-medium text-foreground font-mono">{toolName}</span>
         {!hasSavedExamples && (
-          <span className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+          <span className="flex items-center gap-1 text-xs text-warning">
             <AlertTriangle className="h-3 w-3" />
             {t('config.noExamples')}
           </span>
@@ -1074,7 +1074,7 @@ function FormatGuideToolSection({
                 rows={3}
                 className={`font-mono text-xs flex-1 ${
                   hasContent && !valid
-                    ? 'border-red-500 focus-visible:ring-red-500'
+                    ? 'border-destructive focus-visible:ring-destructive'
                     : ''
                 }`}
               />
@@ -1093,7 +1093,7 @@ function FormatGuideToolSection({
           )
         })}
         {examples.some((ex) => ex.trim() !== '' && !isValidJson(ex.trim())) && (
-          <p className="text-xs text-red-500">{t('config.invalidJson')}</p>
+          <p className="text-xs text-destructive">{t('config.invalidJson')}</p>
         )}
       </div>
 
@@ -1130,10 +1130,10 @@ function FormatGuideToolSection({
           </Button>
         )}
         {saveSuccess && (
-          <span className="text-xs text-green-600 dark:text-green-400">{t('config.saved')}</span>
+          <span className="text-xs text-success">{t('config.saved')}</span>
         )}
         {saveError && (
-          <span className="text-xs text-red-500">{saveError}</span>
+          <span className="text-xs text-destructive">{saveError}</span>
         )}
       </div>
 
@@ -1172,7 +1172,7 @@ function FormatGuideToolSection({
           </pre>
         )}
         {sampleError && (
-          <p className="text-xs text-red-500">{sampleError}</p>
+          <p className="text-xs text-destructive">{sampleError}</p>
         )}
       </div>
     </div>

--- a/frontend/src/pages/PromptPlaygroundPage.tsx
+++ b/frontend/src/pages/PromptPlaygroundPage.tsx
@@ -40,8 +40,8 @@ function ToolCallBlock({ message }: { message: ChatMessage }) {
   const args = tc.arguments
   const hasArgs = Object.keys(args).length > 0
   return (
-    <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs font-mono">
-      <div className="flex items-center gap-1.5 text-amber-400 mb-1">
+    <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs font-mono">
+      <div className="flex items-center gap-1.5 text-warning mb-1">
         <span className="text-[10px] font-semibold uppercase tracking-wider">Tool Call</span>
       </div>
       <div className="text-foreground font-semibold">{tc.name}()</div>
@@ -57,8 +57,8 @@ function ToolCallBlock({ message }: { message: ChatMessage }) {
 function ToolResultBlock({ message }: { message: ChatMessage }) {
   const tr = message.toolResult!
   return (
-    <div className="rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs font-mono">
-      <div className="flex items-center gap-1.5 text-blue-400 mb-1">
+    <div className="rounded-md border border-info/30 bg-info/10 px-3 py-2 text-xs font-mono">
+      <div className="flex items-center gap-1.5 text-info mb-1">
         <span className="text-[10px] font-semibold uppercase tracking-wider">Tool Result</span>
         <span className="text-muted-foreground">{tr.name}</span>
       </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -77,9 +77,9 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 
 // Role icon mapping (only icons -- titles/descriptions come from t())
 const ROLE_ICONS: Record<RoleName, React.ReactNode> = {
-  meta: <Zap className="h-5 w-5 text-amber-500" />,
-  target: <Target className="h-5 w-5 text-blue-500" />,
-  judge: <Scale className="h-5 w-5 text-purple-500" />,
+  meta: <Zap className="h-5 w-5 text-warning" />,
+  target: <Target className="h-5 w-5 text-info" />,
+  judge: <Scale className="h-5 w-5 text-mutation-fresh" />,
 }
 
 // --- API helpers ---
@@ -439,7 +439,7 @@ export default function SettingsPage() {
                 {providerTestStatus?.result && (
                   <div className="shrink-0">
                     {providerTestStatus.result.success ? (
-                      <CheckCircle2 className="h-5 w-5 text-green-500" />
+                      <CheckCircle2 className="h-5 w-5 text-success" />
                     ) : (
                       <span className="flex items-center gap-1 text-xs text-destructive">
                         <XCircle className="h-5 w-5" />
@@ -540,7 +540,7 @@ export default function SettingsPage() {
         <div
           className={`rounded-md px-4 py-3 text-sm ${
             statusBanner.type === 'success'
-              ? 'bg-green-500/10 text-green-700 dark:text-green-400 border border-green-500/20'
+              ? 'bg-success/10 text-success border border-success/20'
               : 'bg-destructive/10 text-destructive border border-destructive/20'
           }`}
         >

--- a/frontend/src/types/evolution.ts
+++ b/frontend/src/types/evolution.ts
@@ -125,21 +125,7 @@ export type EvolutionAction =
   | { type: 'reset' };
 
 // --- Design color constants ---
-
-export const COLORS = {
-  background: '#0c1a14',
-  cardBg: '#142620',
-  border: '#243d33',
-  textPrimary: '#f0f5f3',
-  textSecondary: '#8fad9e',
-  textMuted: '#5c7d6d',
-  green: '#22c55e',
-  blue: '#10b981',
-  amber: '#f59e0b',
-  red: '#ef4444',
-  purple: '#8b5cf6',
-} as const;
-
+// Mutation type colors — categorical palette matching CSS tokens (--mutation-*)
 export const MUTATION_COLORS: Record<string, string> = {
   rcc: '#22c55e',
   structural: '#f59e0b',
@@ -148,6 +134,23 @@ export const MUTATION_COLORS: Record<string, string> = {
   reset: '#ef4444',
   seed: '#94a3b8',
 };
+
+export const MUTATION_FALLBACK = '#64748b';
+
+/** Return a hex color with appended alpha (e.g. '#22c55e' + 0.13 → '#22c55e21') */
+export function mutationBg(type: string): string {
+  return `${MUTATION_COLORS[type] ?? MUTATION_FALLBACK}1a`;
+}
+
+/** Return the mutation color for a type, or the fallback slate. */
+export function mutationColor(type: string): string {
+  return MUTATION_COLORS[type] ?? MUTATION_FALLBACK;
+}
+
+// Score feedback colors — match CSS tokens (--score-*)
+export const SCORE_POSITIVE = '#22c55e';
+export const SCORE_NEGATIVE = '#ef4444';
+export const SCORE_NEUTRAL = '#94a3b8';
 
 // --- Post-run inspection types (Phase 19) ---
 


### PR DESCRIPTION
## Summary
- Replace 40+ hard-coded hex colors and Tailwind utility classes across 25+ component files with centralized semantic CSS custom properties
- Add 18 new CSS tokens for evolution visualizations (mutations, diffs, score feedback, semantic states) with proper light/dark mode OKLCH variants
- Fix responsive layout issues: dashboard grid breakpoints, table overflow, island grid, diff popover width, lineage graph height
- Fix runtime null-safety bug in LineageGraph template comparison
- Zero hard-coded Tailwind color classes remain in the entire `src/` directory

## Test plan
- [x] `npm run build` passes clean
- [x] 21 test files, 181 tests all pass
- [x] Dark mode verified in Chrome — all evolution views, charts, lineage graph, case results
- [x] Light mode verified in Chrome — OKLCH tokens adapt correctly
- [x] Lineage graph renders without null crash on historical runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)