### PR TITLE
fix: harden Docker, nginx, and CORS security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # --------------- Stage 1: Builder ---------------
 FROM python:3.13-slim AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.10.1 /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
@@ -32,6 +32,11 @@ COPY --from=builder /app/.venv /app/.venv
 
 # Copy application source
 COPY --from=builder /app/api /app/api
+
+RUN adduser --disabled-password --gecos '' --uid 1000 appuser \
+    && chown -R appuser:appuser /app
+
+USER appuser
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/api/web/app.py
+++ b/api/web/app.py
@@ -111,8 +111,8 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=cors_origins,
         allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "Accept", "X-Requested-With"],
     )
 
     # --- Exception handlers mapping domain errors to HTTP codes ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     environment:
       POSTGRES_DB: helix
       POSTGRES_USER: helix
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-helix_dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
     # API reverse proxy
     location /api/ {
         proxy_pass http://backend:8000;


### PR DESCRIPTION
## Summary
- Pin uv to exact patch version in Dockerfile
- Add non-root user in backend container runtime stage
- Require POSTGRES_PASSWORD in production compose (no weak default fallback)
- Add security headers to nginx (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy)
- Restrict CORS methods and headers from wildcard to specific values

Closes #58

## Test plan
- [x] 223 backend API tests pass
- [x] Docker build syntax verified
- [x] nginx.conf valid syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)