### PR TITLE
fix: add rate limiting, upload size limits, and EventBus cleanup

### DIFF
--- a/api/web/app.py
+++ b/api/web/app.py
@@ -104,6 +104,11 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    # Rate limiting: per-IP sliding window
+    from api.web.rate_limit import RateLimitMiddleware
+
+    application.add_middleware(RateLimitMiddleware)
+
     # CORS: configurable via CORS_ORIGINS env var (comma-separated)
     cors_origins_str = os.environ.get("CORS_ORIGINS", "http://localhost:5173,http://localhost:3000")
     cors_origins = [origin.strip() for origin in cors_origins_str.split(",")]

--- a/api/web/event_bus.py
+++ b/api/web/event_bus.py
@@ -12,6 +12,7 @@ Exports:
 from __future__ import annotations
 
 import asyncio
+import time
 from collections import deque
 
 from api.web.events import EvolutionEvent
@@ -35,6 +36,8 @@ class EventBus:
         self._buffers: dict[str, deque[EvolutionEvent]] = {}
         # run_id -> set of subscriber queues
         self._subscribers: dict[str, set[asyncio.Queue]] = {}
+        # run_id -> timestamp when cleanup_run was called (for expiry)
+        self._completed_at: dict[str, float] = {}
         # Lock for publish() to ensure monotonic event_ids under concurrency
         self._lock = asyncio.Lock()
 
@@ -132,8 +135,29 @@ class EventBus:
 
         Keeps the ring buffer for late reconnectors, but removes
         the subscriber set so no new events are delivered.
+        Buffers are automatically purged after 30 minutes by purge_stale().
 
         Args:
             run_id: The run to clean up.
         """
         self._subscribers.pop(run_id, None)
+        self._completed_at[run_id] = time.monotonic()
+
+    def purge_stale(self, max_age_seconds: float = 1800) -> int:
+        """Remove ring buffers and counters for runs completed more than max_age_seconds ago.
+
+        Call periodically to prevent unbounded memory growth.
+
+        Returns:
+            Number of runs purged.
+        """
+        now = time.monotonic()
+        stale = [
+            rid for rid, completed in self._completed_at.items()
+            if now - completed > max_age_seconds
+        ]
+        for rid in stale:
+            self._buffers.pop(rid, None)
+            self._counters.pop(rid, None)
+            self._completed_at.pop(rid, None)
+        return len(stale)

--- a/api/web/rate_limit.py
+++ b/api/web/rate_limit.py
@@ -1,0 +1,148 @@
+"""Simple in-memory rate limiter middleware for FastAPI.
+
+Uses a sliding-window counter per client IP. Configurable via env vars:
+  RATE_LIMIT_PER_MINUTE  — general API limit (default: 120)
+  RATE_LIMIT_EVOLUTION   — evolution start limit (default: 10)
+
+No external dependencies required.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from fastapi import Request, Response
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+
+@dataclass
+class _BucketEntry:
+    timestamps: list[float] = field(default_factory=list)
+
+
+class RateLimiter:
+    """Sliding-window rate limiter keyed by client IP."""
+
+    def __init__(self, requests_per_minute: int = 120):
+        self.rpm = requests_per_minute
+        self.window = 60.0  # seconds
+        self._buckets: dict[str, _BucketEntry] = defaultdict(_BucketEntry)
+
+    def is_allowed(self, key: str) -> tuple[bool, int]:
+        """Check if request is allowed. Returns (allowed, remaining)."""
+        now = time.monotonic()
+        entry = self._buckets[key]
+
+        # Prune old timestamps outside the window
+        cutoff = now - self.window
+        entry.timestamps = [t for t in entry.timestamps if t > cutoff]
+
+        remaining = max(0, self.rpm - len(entry.timestamps))
+        if len(entry.timestamps) >= self.rpm:
+            return False, 0
+
+        entry.timestamps.append(now)
+        return True, remaining - 1
+
+    def cleanup(self) -> None:
+        """Remove stale entries (call periodically to prevent memory growth)."""
+        now = time.monotonic()
+        cutoff = now - self.window * 2
+        stale = [k for k, v in self._buckets.items() if not v.timestamps or v.timestamps[-1] < cutoff]
+        for k in stale:
+            del self._buckets[k]
+
+
+# Singleton limiters (lazily initialized, reset via reset_limiters())
+_general_limiter: RateLimiter | None = None
+_evolution_limiter: RateLimiter | None = None
+_cleanup_counter = 0
+
+
+def _get_limiters() -> tuple[RateLimiter, RateLimiter]:
+    global _general_limiter, _evolution_limiter
+    if _general_limiter is None:
+        general_rpm = int(os.environ.get("RATE_LIMIT_PER_MINUTE", "120"))
+        evolution_rpm = int(os.environ.get("RATE_LIMIT_EVOLUTION", "10"))
+        _general_limiter = RateLimiter(general_rpm)
+        _evolution_limiter = RateLimiter(evolution_rpm)
+    return _general_limiter, _evolution_limiter
+
+
+def reset_limiters() -> None:
+    """Reset singleton limiters so they re-read env vars. Used in tests."""
+    global _general_limiter, _evolution_limiter
+    _general_limiter = None
+    _evolution_limiter = None
+
+
+def _client_ip(request: Request) -> str:
+    """Extract client IP, respecting X-Forwarded-For behind reverse proxy."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """FastAPI middleware that enforces per-IP rate limits.
+
+    - General limit applies to all /api/ endpoints
+    - Stricter limit applies to POST /api/evolution/start
+    - Health and WebSocket endpoints are excluded
+    """
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        path = request.url.path
+        method = request.method
+
+        # Skip non-API paths (health, ws, static assets)
+        if not path.startswith("/api/"):
+            return await call_next(request)
+
+        general, evolution = _get_limiters()
+
+        # Allow disabling rate limiting (e.g. in tests) via RATE_LIMIT_PER_MINUTE=0
+        if general.rpm <= 0:
+            return await call_next(request)
+
+        ip = _client_ip(request)
+
+        # Periodic cleanup (every 500 requests)
+        global _cleanup_counter
+        _cleanup_counter += 1
+        if _cleanup_counter >= 500:
+            _cleanup_counter = 0
+            general.cleanup()
+            evolution.cleanup()
+            # Also purge stale EventBus buffers
+            event_bus = getattr(request.app.state, "event_bus", None)
+            if event_bus is not None:
+                event_bus.purge_stale()
+
+        # Stricter limit for evolution start (expensive LLM calls)
+        if method == "POST" and path.rstrip("/") == "/api/evolution/start":
+            allowed, remaining = evolution.is_allowed(ip)
+            if not allowed:
+                return JSONResponse(
+                    status_code=429,
+                    content={"detail": "Rate limit exceeded for evolution runs. Try again later."},
+                    headers={"Retry-After": "60"},
+                )
+
+        # General rate limit
+        allowed, remaining = general.is_allowed(ip)
+        if not allowed:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded. Try again later."},
+                headers={"Retry-After": "60"},
+            )
+
+        response = await call_next(request)
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
+        return response

--- a/api/web/routers/datasets.py
+++ b/api/web/routers/datasets.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from api.dataset.models import PriorityTier, TestCase
 from api.dataset.service import DatasetService
@@ -131,8 +131,12 @@ async def import_cases(
     service: DatasetService = Depends(get_dataset_service),
 ) -> list[TestCaseResponse]:
     """Import test cases from an uploaded JSON or YAML file."""
-    suffix = Path(file.filename).suffix if file.filename else ".json"
+    # Enforce 10 MB upload limit
+    max_size = 10 * 1024 * 1024
     content = await file.read()
+    if len(content) > max_size:
+        raise HTTPException(status_code=413, detail="File too large. Maximum upload size is 10 MB.")
+    suffix = Path(file.filename).suffix if file.filename else ".json"
 
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
         tmp.write(content)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,10 @@ def _clean_gene_env(monkeypatch):
     create_app() don't re-load .env values after cleanup.
     """
     monkeypatch.setattr("api.web.app.load_dotenv", lambda *a, **kw: None)
+    # Disable rate limiting in tests
+    monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", "0")
+    from api.web.rate_limit import reset_limiters
+    reset_limiters()
     for key in list(os.environ):
         if key.startswith("GENE_"):
             monkeypatch.delenv(key)


### PR DESCRIPTION
## Summary
- Per-IP sliding-window rate limiter (120 req/min general, 10 req/min evolution start)
- 10 MB file upload size limit on dataset import
- EventBus.purge_stale() cleans up completed run buffers after 30 min
- Configurable: `RATE_LIMIT_PER_MINUTE=0` disables (used in tests)

Closes #56

## Test plan
- [x] 1208 backend tests pass (rate limiting disabled in test env)
- [x] 181 frontend tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)