### PR TITLE
feat: add JWT authentication and authorization layer

### DIFF
--- a/api/storage/models.py
+++ b/api/storage/models.py
@@ -29,6 +29,24 @@ class Base(DeclarativeBase):
     pass
 
 
+class User(Base):
+    """User accounts for authentication.
+
+    Stores credentials and profile info. Passwords are bcrypt-hashed.
+    The username is used as the foreign key in data-owning tables (denormalized
+    for query simplicity — this tool has at most dozens of users, not millions).
+    """
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    username: Mapped[str] = mapped_column(String(150), unique=True, nullable=False, index=True)
+    email: Mapped[str | None] = mapped_column(String(255), unique=True)
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
 class EvolutionRun(Base):
     """Stores metadata for a single evolution run.
 
@@ -70,6 +88,9 @@ class EvolutionRun(Base):
 
     # RunManager UUID for live-to-completed lookup
     run_uuid: Mapped[str | None] = mapped_column(String(36), index=True)
+
+    # Owner (nullable for backwards compat with pre-auth rows)
+    user_id: Mapped[str | None] = mapped_column(String(150), index=True)
 
     # Relationships
     llm_calls: Mapped[list["LLMCallRecord"]] = relationship(
@@ -245,6 +266,7 @@ class Prompt(Base):
     __tablename__ = "prompts"
 
     id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    user_id: Mapped[str | None] = mapped_column(String(150), index=True)
     purpose: Mapped[str] = mapped_column(Text, nullable=False)
     template: Mapped[str] = mapped_column(Text, nullable=False)
     variables: Mapped[list | None] = mapped_column(JSON)

--- a/api/web/app.py
+++ b/api/web/app.py
@@ -144,8 +144,15 @@ def create_app() -> FastAPI:
     async def health():
         return {"status": "ok"}
 
+    # --- Auth: disabled by default for local single-user mode ---
+    from api.web.auth import get_current_user, get_current_user_noop, is_auth_disabled
+
+    if is_auth_disabled():
+        application.dependency_overrides[get_current_user] = get_current_user_noop
+
     # --- Routers ---
     from api.web.routers import (
+        auth,
         datasets,
         evolution,
         format_guides,
@@ -161,6 +168,7 @@ def create_app() -> FastAPI:
         ws,
     )
 
+    application.include_router(auth.router, prefix="/api/auth", tags=["auth"])
     application.include_router(prompts.router, prefix="/api/prompts", tags=["prompts"])
     application.include_router(datasets.router, prefix="/api/prompts", tags=["datasets"])
     application.include_router(evolution.router, prefix="/api/evolution", tags=["evolution"])

--- a/api/web/auth.py
+++ b/api/web/auth.py
@@ -1,0 +1,142 @@
+"""Authentication and authorization for Helix API.
+
+JWT-based auth with bcrypt password hashing. Disabled by default
+(HELIX_AUTH_DISABLED=true) for local single-user mode.
+
+Env vars:
+    HELIX_AUTH_DISABLED  — "true" to bypass auth (default: "true")
+    HELIX_JWT_EXPIRY_HOURS — token lifetime in hours (default: 24)
+    HELIX_SECRET_KEY — JWT signing key (reuses the encryption secret)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from passlib.context import CryptContext
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.storage.models import User
+
+# --------------- Configuration ---------------
+
+_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def _get_secret_key() -> str:
+    key = os.environ.get("HELIX_SECRET_KEY", "")
+    if not key:
+        key = "helix-dev-secret-change-me"
+    return key
+
+
+def _get_expiry_hours() -> int:
+    return int(os.environ.get("HELIX_JWT_EXPIRY_HOURS", "24"))
+
+
+def is_auth_disabled() -> bool:
+    return os.environ.get("HELIX_AUTH_DISABLED", "true").lower() == "true"
+
+
+# --------------- Password hashing ---------------
+
+
+def hash_password(password: str) -> str:
+    return _pwd_context.hash(password)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return _pwd_context.verify(plain, hashed)
+
+
+# --------------- JWT ---------------
+
+
+def create_access_token(username: str) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(hours=_get_expiry_hours())
+    payload = {"sub": username, "exp": expire}
+    return jwt.encode(payload, _get_secret_key(), algorithm="HS256")
+
+
+def decode_access_token(token: str) -> str:
+    """Decode JWT and return the username. Raises jwt.PyJWTError on failure."""
+    payload = jwt.decode(token, _get_secret_key(), algorithms=["HS256"])
+    username: str | None = payload.get("sub")
+    if username is None:
+        raise jwt.InvalidTokenError("Missing subject claim")
+    return username
+
+
+# --------------- Pydantic schemas ---------------
+
+
+class RegisterRequest(BaseModel):
+    username: str
+    password: str
+    email: str | None = None
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    username: str
+
+
+class UserInfo(BaseModel):
+    username: str
+    email: str | None
+
+
+class AuthStatusResponse(BaseModel):
+    auth_required: bool
+
+
+# --------------- Dependencies ---------------
+
+# Sentinel local user for when auth is disabled
+_LOCAL_USER = User(id=0, username="local", hashed_password="", is_active=True)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> User:
+    """FastAPI dependency: extract and validate JWT, return User.
+
+    When auth is disabled (default), this is overridden by get_current_user_noop
+    via dependency_overrides in the app factory.
+    """
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    try:
+        username = decode_access_token(credentials.credentials)
+    except jwt.PyJWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    # Note: we don't do a DB lookup here for performance. The JWT contains the
+    # username which is sufficient for query filtering. A DB lookup would be
+    # needed if we supported user deactivation with immediate token revocation.
+    return User(id=0, username=username, hashed_password="", is_active=True)
+
+
+async def get_current_user_noop() -> User:
+    """No-op dependency: returns a fixed 'local' user when auth is disabled."""
+    return _LOCAL_USER

--- a/api/web/routers/auth.py
+++ b/api/web/routers/auth.py
@@ -1,0 +1,89 @@
+"""Authentication endpoints: register, login, me, status."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from api.storage.models import User
+from api.web.auth import (
+    AuthStatusResponse,
+    LoginRequest,
+    RegisterRequest,
+    TokenResponse,
+    UserInfo,
+    create_access_token,
+    get_current_user,
+    hash_password,
+    is_auth_disabled,
+    verify_password,
+)
+from api.web.deps import _get_session_factory
+
+router = APIRouter()
+
+
+@router.post("/register", response_model=TokenResponse, status_code=201)
+async def register(
+    body: RegisterRequest,
+    session_factory: async_sessionmaker = Depends(_get_session_factory),
+) -> TokenResponse:
+    """Register a new user and return a JWT."""
+    if is_auth_disabled():
+        raise HTTPException(status_code=400, detail="Authentication is disabled")
+
+    async with session_factory() as session:
+        existing = await session.execute(
+            select(User).where(User.username == body.username)
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise HTTPException(status_code=409, detail="Username already taken")
+
+        user = User(
+            username=body.username,
+            email=body.email,
+            hashed_password=hash_password(body.password),
+        )
+        session.add(user)
+        await session.commit()
+
+    token = create_access_token(body.username)
+    return TokenResponse(access_token=token, username=body.username)
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(
+    body: LoginRequest,
+    session_factory: async_sessionmaker = Depends(_get_session_factory),
+) -> TokenResponse:
+    """Authenticate and return a JWT."""
+    if is_auth_disabled():
+        raise HTTPException(status_code=400, detail="Authentication is disabled")
+
+    async with session_factory() as session:
+        result = await session.execute(
+            select(User).where(User.username == body.username)
+        )
+        user = result.scalar_one_or_none()
+
+    if user is None or not verify_password(body.password, user.hashed_password):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    if not user.is_active:
+        raise HTTPException(status_code=401, detail="Account is deactivated")
+
+    token = create_access_token(user.username)
+    return TokenResponse(access_token=token, username=user.username)
+
+
+@router.get("/me", response_model=UserInfo)
+async def me(user: User = Depends(get_current_user)) -> UserInfo:
+    """Return the current authenticated user's info."""
+    return UserInfo(username=user.username, email=user.email)
+
+
+@router.get("/status", response_model=AuthStatusResponse)
+async def auth_status() -> AuthStatusResponse:
+    """Return whether authentication is required (public endpoint)."""
+    return AuthStatusResponse(auth_required=not is_auth_disabled())

--- a/api/web/routers/datasets.py
+++ b/api/web/routers/datasets.py
@@ -21,6 +21,8 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from api.dataset.models import PriorityTier, TestCase
 from api.dataset.service import DatasetService
+from api.storage.models import User
+from api.web.auth import get_current_user
 from api.web.deps import get_dataset_service
 from api.web.schemas import (
     TestCaseCreateRequest,
@@ -50,6 +52,7 @@ def _case_to_response(case: TestCase) -> TestCaseResponse:
 async def list_cases(
     prompt_id: str,
     service: DatasetService = Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ) -> list[TestCaseResponse]:
     """List all test cases for a prompt."""
     cases = await service.list_cases(prompt_id)
@@ -61,6 +64,7 @@ async def get_case(
     prompt_id: str,
     case_id: str,
     service: DatasetService = Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ) -> TestCaseResponse:
     """Get a single test case by ID."""
     case = await service.get_case(prompt_id, case_id)
@@ -72,6 +76,7 @@ async def add_case(
     prompt_id: str,
     body: TestCaseCreateRequest,
     service: DatasetService = Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ) -> TestCaseResponse:
     """Add a new test case to a prompt's dataset."""
     case = TestCase(
@@ -96,6 +101,7 @@ async def update_case(
     case_id: str,
     body: TestCaseUpdateRequest,
     service: DatasetService = Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ) -> TestCaseResponse:
     """Update an existing test case (partial update)."""
     existing = await service.get_case(prompt_id, case_id)
@@ -119,6 +125,7 @@ async def delete_case(
     prompt_id: str,
     case_id: str,
     service: DatasetService = Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ) -> None:
     """Delete a test case."""
     await service.delete_case(prompt_id, case_id)
@@ -129,6 +136,7 @@ async def import_cases(
     prompt_id: str,
     file: UploadFile = File(...),
     service: DatasetService = Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ) -> list[TestCaseResponse]:
     """Import test cases from an uploaded JSON or YAML file."""
     # Enforce 10 MB upload limit

--- a/api/web/routers/evolution.py
+++ b/api/web/routers/evolution.py
@@ -13,6 +13,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from api.config.models import GenerationConfig
 from api.evolution.models import EvolutionConfig
+from api.storage.models import User
+from api.web.auth import get_current_user
 from api.web.deps import get_config, get_dataset_service, get_registry
 from api.web.schemas import EvolutionRunRequest, EvolutionRunStatus
 
@@ -26,6 +28,7 @@ async def start_evolution(
     config=Depends(get_config),
     registry=Depends(get_registry),
     dataset_service=Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ):
     """Start an evolution run as a background task.
 
@@ -146,7 +149,7 @@ async def start_evolution(
 
 
 @router.get("/active", response_model=list[EvolutionRunStatus])
-async def list_active_runs(request: Request):
+async def list_active_runs(request: Request, user: User = Depends(get_current_user)):
     """List all currently active (in-memory) evolution runs."""
     run_manager = request.app.state.run_manager
     all_statuses = run_manager.list_runs()
@@ -154,7 +157,7 @@ async def list_active_runs(request: Request):
 
 
 @router.post("/{run_id}/stop")
-async def stop_evolution(run_id: str, request: Request):
+async def stop_evolution(run_id: str, request: Request, user: User = Depends(get_current_user)):
     """Cancel a running evolution task."""
     run_manager = request.app.state.run_manager
     stopped = await run_manager.stop_run(run_id)
@@ -164,7 +167,7 @@ async def stop_evolution(run_id: str, request: Request):
 
 
 @router.get("/{run_id}/status", response_model=EvolutionRunStatus)
-async def get_run_status(run_id: str, request: Request):
+async def get_run_status(run_id: str, request: Request, user: User = Depends(get_current_user)):
     """Get the current status of an evolution run."""
     run_manager = request.app.state.run_manager
     status = run_manager.get_status(run_id)

--- a/api/web/routers/format_guides.py
+++ b/api/web/routers/format_guides.py
@@ -17,7 +17,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.config.models import GeneConfig
 from api.gateway.factory import create_provider
 from api.registry.llm_mocker import LLMMocker
-from api.storage.models import PromptConfig, ToolFormatGuide
+from api.storage.models import PromptConfig, ToolFormatGuide, User
+from api.web.auth import get_current_user
 from api.web.deps import get_config, get_db_session
 from api.web.schemas import (
     FormatGuideResponse,
@@ -47,6 +48,7 @@ def _row_to_response(row: ToolFormatGuide) -> FormatGuideResponse:
 async def list_format_guides(
     prompt_id: str,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> list[FormatGuideResponse]:
     """List all format guides for a prompt."""
     stmt = select(ToolFormatGuide).where(ToolFormatGuide.prompt_id == prompt_id)
@@ -64,6 +66,7 @@ async def upsert_format_guide(
     tool_name: str,
     examples: list[str],
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> FormatGuideResponse:
     """Create or update a format guide for a specific tool.
 
@@ -112,6 +115,7 @@ async def delete_format_guide(
     prompt_id: str,
     tool_name: str,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> dict:
     """Delete a format guide for a specific tool."""
     stmt = select(ToolFormatGuide).where(
@@ -138,6 +142,7 @@ async def generate_sample(
     body: GenerateSampleRequest,
     config: GeneConfig = Depends(get_config),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> GenerateSampleResponse:
     """Generate a sample mock response using the LLM tool mocker.
 

--- a/api/web/routers/history.py
+++ b/api/web/routers/history.py
@@ -13,8 +13,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 
 from api.storage.database import Database
-from api.storage.models import EvolutionRun
+from api.storage.models import EvolutionRun, User
 from api.storage.queries import get_evolution_history
+from api.web.auth import get_current_user
 from api.web.deps import get_database
 from api.web.schemas import EvolutionRunHistory, RunResultsResponse
 
@@ -79,6 +80,7 @@ def _build_run_results_response(run: EvolutionRun) -> RunResultsResponse:
 async def get_history(
     prompt_id: str,
     db: Database = Depends(get_database),
+    user: User = Depends(get_current_user),
 ) -> list[EvolutionRunHistory]:
     """List evolution runs for a prompt, ordered by most recent first."""
     session = await db.get_session()
@@ -93,6 +95,7 @@ async def get_history(
 async def get_run_results_by_uuid(
     run_uuid: str,
     db: Database = Depends(get_database),
+    user: User = Depends(get_current_user),
 ) -> RunResultsResponse:
     """Get full results for a completed evolution run by its UUID.
 
@@ -115,6 +118,7 @@ async def get_run_results_by_uuid(
 async def get_run_detail(
     run_id: int,
     db: Database = Depends(get_database),
+    user: User = Depends(get_current_user),
 ) -> EvolutionRunHistory:
     """Get a single evolution run by its database ID."""
     session = await db.get_session()
@@ -133,6 +137,7 @@ async def get_run_detail(
 async def get_run_results(
     run_id: int,
     db: Database = Depends(get_database),
+    user: User = Depends(get_current_user),
 ) -> RunResultsResponse:
     """Get full results for a completed evolution run.
 

--- a/api/web/routers/models.py
+++ b/api/web/routers/models.py
@@ -20,6 +20,8 @@ from api.gateway.model_listing import (
     fetch_openai_models,
     fetch_openrouter_models,
 )
+from api.storage.models import User
+from api.web.auth import get_current_user
 from api.web.deps import get_config
 
 router = APIRouter()
@@ -36,6 +38,7 @@ _PROVIDER_CONFIG: dict[str, tuple[str, str, object]] = {
 async def list_models(
     provider: str = Query(..., description="Provider name: 'openrouter', 'gemini', or 'openai'"),
     config: GeneConfig = Depends(get_config),
+    user: User = Depends(get_current_user),
 ) -> list[ModelInfo]:
     """List available models from the specified provider.
 

--- a/api/web/routers/personas.py
+++ b/api/web/routers/personas.py
@@ -20,7 +20,8 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.storage.models import Persona
+from api.storage.models import Persona, User
+from api.web.auth import get_current_user
 from api.web.deps import get_db_session
 from api.web.schemas import (
     CreatePersonaRequest,
@@ -154,6 +155,7 @@ async def _materialize_defaults_to_db(session: AsyncSession, prompt_id: str) -> 
 async def list_personas(
     prompt_id: str,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> list[PersonaProfileResponse]:
     """List all personas for a prompt. Returns defaults if no DB rows exist."""
     return await _load_personas_from_db(session, prompt_id)
@@ -168,6 +170,7 @@ async def create_persona(
     prompt_id: str,
     body: CreatePersonaRequest,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PersonaProfileResponse:
     """Create a new persona for a prompt."""
     # Materialize defaults first (if needed)
@@ -206,6 +209,7 @@ async def update_persona(
     persona_id: str,
     body: UpdatePersonaRequest,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PersonaProfileResponse:
     """Update an existing persona's fields (partial update)."""
     stmt = select(Persona).where(
@@ -233,6 +237,7 @@ async def delete_persona(
     prompt_id: str,
     persona_id: str,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> Response:
     """Delete a persona by ID."""
     stmt = select(Persona).where(
@@ -257,6 +262,7 @@ async def delete_persona(
 async def export_personas(
     prompt_id: str,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> list[PersonaProfileResponse]:
     """Export all personas as a JSON array."""
     return await _load_personas_from_db(session, prompt_id)
@@ -270,6 +276,7 @@ async def import_personas(
     prompt_id: str,
     body: list[CreatePersonaRequest],
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> ImportPersonasResponse:
     """Import personas from a JSON array, skipping existing IDs."""
     # Materialize defaults first

--- a/api/web/routers/playground.py
+++ b/api/web/routers/playground.py
@@ -36,8 +36,13 @@ from api.gateway.factory import create_provider
 from api.registry.llm_mocker import LLMMocker
 from api.registry.schemas import MockDefinition
 from api.registry.service import PromptRegistry
-from api.registry.tool_resolver import DEFAULT_MAX_TOOL_STEPS, normalize_tool_call, resolve_tool_call
-from api.storage.models import PlaygroundVariable, PromptConfig
+from api.registry.tool_resolver import (
+    DEFAULT_MAX_TOOL_STEPS,
+    normalize_tool_call,
+    resolve_tool_call,
+)
+from api.storage.models import PlaygroundVariable, PromptConfig, User
+from api.web.auth import get_current_user
 from api.web.deps import get_config, get_db_session, get_registry
 from api.web.schemas import (
     ChatRequest,
@@ -57,6 +62,7 @@ logger = logging.getLogger(__name__)
 async def get_variables(
     prompt_id: str,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PlaygroundVariablesResponse:
     """Return all saved variable values for a prompt from DB."""
     stmt = select(PlaygroundVariable).where(PlaygroundVariable.prompt_id == prompt_id)
@@ -71,6 +77,7 @@ async def save_variables(
     prompt_id: str,
     body: PlaygroundVariablesUpdateRequest,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PlaygroundVariablesResponse:
     """Save variable values to DB (upsert per variable_name).
 
@@ -110,6 +117,7 @@ async def save_variables(
 async def get_playground_config(
     prompt_id: str,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PlaygroundConfigResponse:
     """Return playground config (turn_limit, budget) for a prompt."""
     result = await session.execute(
@@ -127,6 +135,7 @@ async def update_playground_config(
     prompt_id: str,
     body: PlaygroundConfigUpdateRequest,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PlaygroundConfigResponse:
     """Update playground config (turn_limit, budget) for a prompt."""
     result = await session.execute(
@@ -164,6 +173,7 @@ async def chat(
     config: GeneConfig = Depends(get_config),
     registry: PromptRegistry = Depends(get_registry),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ):
     """Stream an LLM chat response via Server-Sent Events.
 

--- a/api/web/routers/presets.py
+++ b/api/web/routers/presets.py
@@ -19,7 +19,8 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.storage.models import Preset
+from api.storage.models import Preset, User
+from api.web.auth import get_current_user
 from api.web.deps import get_db_session
 from api.web.schemas import (
     CreatePresetRequest,
@@ -47,6 +48,7 @@ def _preset_to_response(preset: Preset) -> PresetResponse:
 async def list_presets(
     type: str | None = None,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> list[PresetResponse]:
     """List all presets, optionally filtered by type."""
     stmt = select(Preset)
@@ -61,6 +63,7 @@ async def list_presets(
 async def create_preset(
     body: CreatePresetRequest,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PresetResponse:
     """Create a new preset."""
     preset = Preset(
@@ -79,6 +82,7 @@ async def create_preset(
 async def get_preset(
     preset_id: int,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PresetResponse:
     """Get a single preset by ID."""
     preset = await session.get(Preset, preset_id)
@@ -92,6 +96,7 @@ async def update_preset(
     preset_id: int,
     body: UpdatePresetRequest,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PresetResponse:
     """Update an existing preset (partial update)."""
     preset = await session.get(Preset, preset_id)
@@ -111,6 +116,7 @@ async def update_preset(
 async def delete_preset(
     preset_id: int,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> Response:
     """Delete a preset."""
     preset = await session.get(Preset, preset_id)
@@ -126,6 +132,7 @@ async def delete_preset(
 async def set_default(
     preset_id: int,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PresetResponse:
     """Mark a preset as default, clearing other defaults of the same type."""
     preset = await session.get(Preset, preset_id)

--- a/api/web/routers/prompts.py
+++ b/api/web/routers/prompts.py
@@ -23,7 +23,8 @@ from api.registry.models import PromptRegistration, VariableDefinition
 from api.registry.schemas import PromptConfigSchema
 from api.registry.service import PromptRegistry, _extract_anchor_variables
 from api.storage.models import Prompt as PromptModel
-from api.storage.models import PromptConfig
+from api.storage.models import PromptConfig, User
+from api.web.auth import get_current_user
 from api.web.deps import get_config, get_db_session, get_registry
 from api.web.schemas import (
     AcceptVersionRequest,
@@ -60,6 +61,7 @@ def _record_to_summary(record) -> PromptSummary:
 @router.get("/", response_model=list[PromptSummary])
 async def list_prompts(
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> list[PromptSummary]:
     """List all registered prompts."""
     prompt_ids = await registry.list_prompts()
@@ -154,6 +156,7 @@ def _merge_overrides_onto_config(config: GeneConfig, overrides_dict: dict) -> Ge
 async def extract_variables(
     body: ExtractVariablesRequest,
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> ExtractVariablesResponse:
     """Extract Jinja2 template variables from a template string.
 
@@ -174,6 +177,7 @@ async def get_prompt_config(
     config: GeneConfig = Depends(get_config),
     session: AsyncSession = Depends(get_db_session),
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> PromptConfigResponse:
     """Return prompt config with provenance info.
 
@@ -207,6 +211,7 @@ async def update_prompt_config(
     config: GeneConfig = Depends(get_config),
     session: AsyncSession = Depends(get_db_session),
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> PromptConfigResponse:
     """Update per-prompt config in DB PromptConfig table.
 
@@ -265,6 +270,7 @@ async def get_prompt(
     prompt_id: str,
     registry: PromptRegistry = Depends(get_registry),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PromptDetail:
     """Get a prompt's full detail including template text from DB."""
     record = await registry.load_prompt(prompt_id)
@@ -311,6 +317,7 @@ async def get_prompt(
 async def create_prompt(
     body: CreatePromptRequest,
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> PromptSummary:
     """Register a new prompt."""
     # Convert body.variables (list[dict] | None) to list[VariableDefinition] | None
@@ -335,6 +342,7 @@ async def create_prompt(
 async def delete_prompt(
     prompt_id: str,
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> None:
     """Delete a prompt and all associated data."""
     await registry.delete_prompt(prompt_id)
@@ -346,6 +354,7 @@ async def update_prompt(
     body: dict,
     registry: PromptRegistry = Depends(get_registry),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PromptSummary:
     """Partially update a prompt's metadata (e.g. purpose)."""
     result = await session.execute(
@@ -369,6 +378,7 @@ async def update_template(
     prompt_id: str,
     body: UpdateTemplateRequest,
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> PromptSummary:
     """Update a prompt's template text."""
     record = await registry.update_template(prompt_id, body.template, "Update via API")
@@ -381,6 +391,7 @@ async def update_variable_definitions(
     body: UpdateVariablesRequest,
     registry: PromptRegistry = Depends(get_registry),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PromptSummary:
     """Update variable definitions for a prompt.
 
@@ -417,6 +428,7 @@ async def update_mocks(
     prompt_id: str,
     body: UpdateMocksRequest,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> dict:
     """Update mock definitions for a prompt.
 
@@ -439,6 +451,7 @@ async def update_tools(
     prompt_id: str,
     body: UpdateToolsRequest,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> dict:
     """Update tool definitions for a prompt."""
     result = await session.execute(
@@ -457,6 +470,7 @@ async def update_tools(
 async def get_mocks(
     prompt_id: str,
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> dict:
     """Get mock definitions for a prompt."""
     result = await session.execute(
@@ -477,6 +491,7 @@ async def list_versions(
     prompt_id: str,
     registry: PromptRegistry = Depends(get_registry),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> list[PromptVersionResponse]:
     """List all versions for a prompt, ordered by version number."""
 
@@ -512,6 +527,7 @@ async def get_version(
     version: int,
     registry: PromptRegistry = Depends(get_registry),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> PromptVersionResponse:
     """Get a specific version of a prompt."""
 
@@ -553,6 +569,7 @@ async def activate_version(
     prompt_id: str,
     version: int,
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> PromptVersionResponse:
     """Activate a specific version for a prompt."""
     # activate_version raises PromptNotFoundError -> 404 via exception handler
@@ -574,6 +591,7 @@ async def accept_version(
     prompt_id: str,
     body: AcceptVersionRequest,
     registry: PromptRegistry = Depends(get_registry),
+    user: User = Depends(get_current_user),
 ) -> PromptVersionResponse:
     """Accept an evolved template as a new version.
 

--- a/api/web/routers/settings.py
+++ b/api/web/routers/settings.py
@@ -19,7 +19,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.config.models import GeneConfig, GenerationConfig
 from api.gateway.registry import PROVIDER_REGISTRY, SUPPORTED_PROVIDERS
 from api.storage.encryption import get_encryptor
-from api.storage.models import Setting
+from api.storage.models import Setting, User
+from api.web.auth import get_current_user
 from api.web.deps import get_config, get_db_session
 from api.web.schemas import (
     RoleConfig,
@@ -149,6 +150,7 @@ def _merge_db_onto_config(config: GeneConfig, db_data: dict) -> GeneConfig:
 async def get_settings(
     config: GeneConfig = Depends(get_config),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> SettingsResponse:
     """Return current configuration with masked API keys.
 
@@ -163,7 +165,7 @@ async def get_settings(
 
 
 @router.get("/defaults", response_model=SettingsResponse)
-async def get_defaults() -> SettingsResponse:
+async def get_defaults(user: User = Depends(get_current_user)) -> SettingsResponse:
     """Return GeneConfig default values (for 'Reset to Defaults' feature)."""
     defaults = GeneConfig()
     return _build_settings_response(defaults)
@@ -174,6 +176,7 @@ async def update_settings(
     body: SettingsUpdateRequest,
     config: GeneConfig = Depends(get_config),
     session: AsyncSession = Depends(get_db_session),
+    user: User = Depends(get_current_user),
 ) -> SettingsResponse:
     """Update configuration in database and return new settings.
 
@@ -260,7 +263,7 @@ async def update_settings(
 
 
 @router.post("/test-connection", response_model=TestConnectionResponse)
-async def test_connection(body: TestConnectionRequest) -> TestConnectionResponse:
+async def test_connection(body: TestConnectionRequest, user: User = Depends(get_current_user)) -> TestConnectionResponse:
     """Validate an API key by making a lightweight request to the provider.
 
     Attempts to list models from the provider. Returns success/failure.

--- a/api/web/routers/synthesis.py
+++ b/api/web/routers/synthesis.py
@@ -19,7 +19,9 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from api.dataset.models import TestCase
 from api.registry.tool_resolver import DEFAULT_MAX_TOOL_STEPS
+from api.storage.models import User
 from api.synthesis.models import SynthesisConfig
+from api.web.auth import get_current_user
 from api.web.deps import get_config, get_dataset_service, get_registry
 from api.web.schemas import (
     ReviewRequest,
@@ -41,6 +43,7 @@ async def start_synthesis(
     config=Depends(get_config),
     registry=Depends(get_registry),
     dataset_service=Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ):
     """Start a synthesis run as a background task.
 
@@ -433,6 +436,7 @@ async def review_conversations(
     body: ReviewRequest,
     request: Request,
     dataset_service=Depends(get_dataset_service),
+    user: User = Depends(get_current_user),
 ):
     """Submit approve/reject decisions for synthesized conversations.
 

--- a/api/web/routers/wizard.py
+++ b/api/web/routers/wizard.py
@@ -14,7 +14,9 @@ from fastapi.responses import JSONResponse
 
 from api.config.models import GeneConfig
 from api.gateway.factory import create_provider
+from api.storage.models import User
 from api.types import ModelRole
+from api.web.auth import get_current_user
 from api.web.deps import get_config
 from api.web.schemas import WizardGenerateRequest, WizardGenerateResponse
 
@@ -112,6 +114,7 @@ def _clean_yaml_response(text: str) -> str:
 async def generate_template(
     body: WizardGenerateRequest,
     config: GeneConfig = Depends(get_config),
+    user: User = Depends(get_current_user),
 ) -> WizardGenerateResponse:
     """Generate a prompt template from wizard answers using the meta model."""
     try:

--- a/api/web/routers/ws.py
+++ b/api/web/routers/ws.py
@@ -16,13 +16,16 @@ from __future__ import annotations
 
 import asyncio
 
+import jwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from api.web.auth import decode_access_token, is_auth_disabled
 
 router = APIRouter()
 
 
 @router.websocket("/ws/evolution/{run_id}")
-async def evolution_ws(websocket: WebSocket, run_id: str) -> None:
+async def evolution_ws(websocket: WebSocket, run_id: str, token: str | None = None) -> None:
     """Stream evolution events over WebSocket with replay support.
 
     Accepts the connection, sends a connected message, waits for a
@@ -33,7 +36,17 @@ async def evolution_ws(websocket: WebSocket, run_id: str) -> None:
     Args:
         websocket: The WebSocket connection.
         run_id: Unique identifier for the evolution run to stream.
+        token: Optional JWT token for authentication.
     """
+    if not is_auth_disabled():
+        if token is None:
+            await websocket.close(code=4001, reason="Missing auth token")
+            return
+        try:
+            decode_access_token(token)
+        except jwt.PyJWTError:
+            await websocket.close(code=4001, reason="Invalid token")
+            return
     await websocket.accept()
     event_bus = websocket.app.state.event_bus
 
@@ -79,7 +92,7 @@ async def evolution_ws(websocket: WebSocket, run_id: str) -> None:
 
 
 @router.websocket("/ws/synthesis/{run_id}")
-async def synthesis_ws(websocket: WebSocket, run_id: str) -> None:
+async def synthesis_ws(websocket: WebSocket, run_id: str, token: str | None = None) -> None:
     """Stream synthesis events over WebSocket with replay support.
 
     Follows the same protocol as evolution_ws: connected -> subscribe ->
@@ -88,7 +101,17 @@ async def synthesis_ws(websocket: WebSocket, run_id: str) -> None:
     Args:
         websocket: The WebSocket connection.
         run_id: Unique identifier for the synthesis run to stream.
+        token: Optional JWT token for authentication.
     """
+    if not is_auth_disabled():
+        if token is None:
+            await websocket.close(code=4001, reason="Missing auth token")
+            return
+        try:
+            decode_access_token(token)
+        except jwt.PyJWTError:
+            await websocket.close(code=4001, reason="Invalid token")
+            return
     await websocket.accept()
     event_bus = websocket.app.state.event_bus
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ web = [
     "aiosqlite>=0.22.1",
     "asyncpg>=0.29.0",
     "cryptography>=42.0",
+    "PyJWT>=2.8.0",
+    "passlib[bcrypt]>=1.7.4",
 ]
 
 [dependency-groups]

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -17,12 +17,13 @@ from api.web.deps import (
     get_db_session,
     get_registry,
 )
+from api.web.auth import get_current_user
 from api.web.event_bus import EventBus
 from api.web.run_manager import RunManager
 from api.config.models import GeneConfig
 from api.dataset.service import DatasetService
 from api.registry.service import PromptRegistry
-from api.storage.models import Base
+from api.storage.models import Base, User
 
 
 @pytest.fixture
@@ -80,6 +81,10 @@ def app(db_engine) -> FastAPI:
     application.dependency_overrides[get_dataset_service] = lambda: test_dataset_service
     application.dependency_overrides[get_db_session] = _override_db_session
     application.dependency_overrides[_get_session_factory] = lambda: session_factory
+
+    # Override auth with a fixed test user
+    _test_user = User(id=1, username="testuser", hashed_password="", is_active=True)
+    application.dependency_overrides[get_current_user] = lambda: _test_user
 
     # Manually set up app state that lifespan would create
     # (ASGI transport does not invoke lifespan events)

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,72 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -420,6 +486,8 @@ web = [
     { name = "asyncpg" },
     { name = "cryptography" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "passlib", extra = ["bcrypt"] },
+    { name = "pyjwt" },
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 
@@ -442,8 +510,10 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "openai", specifier = ">=2.8.0" },
+    { name = "passlib", extras = ["bcrypt"], marker = "extra == 'web'", specifier = ">=1.7.4" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pydantic-settings", specifier = ">=2.13.0" },
+    { name = "pyjwt", marker = "extra == 'web'", specifier = ">=2.8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'web'", specifier = ">=2.0.0" },
@@ -694,6 +764,20 @@ wheels = [
 ]
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
+]
+
+[package.optional-dependencies]
+bcrypt = [
+    { name = "bcrypt" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -876,6 +960,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- JWT-based authentication with bcrypt password hashing
- User model + registration/login/me/status endpoints
- `get_current_user` dependency added to all 49 route handlers (13 routers)
- Token-based WebSocket authentication (query param)
- **Disabled by default** (`HELIX_AUTH_DISABLED=true`) for backwards compatibility
- `user_id` column added to Prompt and EvolutionRun tables (nullable)
- PyJWT + passlib[bcrypt] added to `[web]` optional deps

Closes #55

## How to enable auth
```bash
export HELIX_AUTH_DISABLED=false
export HELIX_SECRET_KEY=your-secret-key
```

Then register: `POST /api/auth/register` with `{"username": "...", "password": "..."}`

## Cross-component check
- CLI: unaffected (imports core engine directly)
- Frontend: works unchanged when auth disabled; frontend auth integration (login page, JWT interceptor) is a follow-up

## Test plan
- [x] 1208 backend tests pass
- [x] 181 frontend tests pass
- [x] Build clean
- [x] Auth disabled mode verified (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)