### PR TITLE
feat: frontend login page, per-user settings, WebSocket auth tokens

### DIFF
--- a/api/storage/models.py
+++ b/api/storage/models.py
@@ -124,20 +124,22 @@ class LLMCallRecord(Base):
 
 
 class Setting(Base):
-    """Key-value store for global configuration.
+    """Key-value store for per-user configuration.
 
     Each row represents a config category (e.g. "global_config",
-    "generation_defaults", "api_keys"). The data column holds the actual
-    config dict as JSON.
+    "generation_defaults", "api_keys") scoped to a user.
+    The data column holds the actual config dict as JSON.
 
     API keys are stored encrypted (Fernet) in the "api_keys" category.
+    user_id is nullable for backwards compat with pre-auth rows.
     """
 
     __tablename__ = "settings"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    category: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    category: Mapped[str] = mapped_column(String(100), nullable=False)
     data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    user_id: Mapped[str | None] = mapped_column(String(150), index=True)
 
 
 class PromptConfig(Base):

--- a/api/web/routers/settings.py
+++ b/api/web/routers/settings.py
@@ -87,27 +87,48 @@ def _build_settings_response(
     )
 
 
-async def _load_db_settings(session: AsyncSession) -> dict:
+def _setting_filter(category: str, user_id: str | None):
+    """Build a SQLAlchemy filter for a setting by category + user scope.
+
+    Matches the user's own rows, or legacy rows with NULL user_id.
+    """
+    from sqlalchemy import or_
+
+    base = Setting.category == category
+    if user_id and user_id != "local":
+        return base, or_(Setting.user_id == user_id, Setting.user_id.is_(None))
+    return base, Setting.user_id.is_(None)
+
+
+async def _get_setting(session: AsyncSession, category: str, user_id: str | None) -> Setting | None:
+    """Fetch a setting row scoped to a user. Prefers user-owned over legacy NULL rows."""
+    cat_filter, user_filter = _setting_filter(category, user_id)
+    result = await session.execute(
+        select(Setting).where(cat_filter, user_filter).order_by(Setting.user_id.desc())
+    )
+    return result.scalars().first()
+
+
+async def _load_db_settings(session: AsyncSession, user_id: str | None = None) -> dict:
     """Load global_config, generation_defaults, and api_keys from DB into a flat dict.
 
+    Settings are scoped per-user when auth is enabled. Falls back to legacy
+    NULL user_id rows for backwards compatibility.
     API keys stored in the "api_keys" category are decrypted before merging.
     Returns a dict suitable for merging onto GeneConfig defaults.
     """
     merged: dict = {}
 
-    result = await session.execute(select(Setting).where(Setting.category == "global_config"))
-    global_row = result.scalar_one_or_none()
+    global_row = await _get_setting(session, "global_config", user_id)
     if global_row is not None:
         merged.update(global_row.data)
 
-    result = await session.execute(select(Setting).where(Setting.category == "generation_defaults"))
-    gen_row = result.scalar_one_or_none()
+    gen_row = await _get_setting(session, "generation_defaults", user_id)
     if gen_row is not None:
         merged["generation"] = gen_row.data
 
     # Load and decrypt API keys stored in DB
-    result = await session.execute(select(Setting).where(Setting.category == "api_keys"))
-    keys_row = result.scalar_one_or_none()
+    keys_row = await _get_setting(session, "api_keys", user_id)
     if keys_row is not None:
         encryptor = get_encryptor()
         for field, encrypted_value in keys_row.data.items():
@@ -157,7 +178,7 @@ async def get_settings(
     Reads DB Setting rows (including encrypted API keys) and merges onto
     GeneConfig defaults. Env var keys take priority over DB-stored keys.
     """
-    db_data = await _load_db_settings(session)
+    db_data = await _load_db_settings(session, user.username)
     # Check if any API keys are stored in DB (before merge overrides them)
     has_db_keys = any(k in db_data for k in _API_KEY_FIELDS)
     merged = _merge_db_onto_config(config, db_data)
@@ -203,44 +224,35 @@ async def update_settings(
             elif value:
                 encrypted_keys[field] = value  # Already encrypted, keep as-is
 
-        result = await session.execute(
-            select(Setting).where(Setting.category == "api_keys")
-        )
-        keys_row = result.scalar_one_or_none()
+        keys_row = await _get_setting(session, "api_keys", user.username)
 
         if keys_row is not None:
             merged_keys = {**keys_row.data, **encrypted_keys}
             keys_row.data = merged_keys
         else:
-            keys_row = Setting(category="api_keys", data=encrypted_keys)
+            keys_row = Setting(category="api_keys", data=encrypted_keys, user_id=user.username)
             session.add(keys_row)
 
     # --- Upsert global_config ---
     if update_data:
-        result = await session.execute(
-            select(Setting).where(Setting.category == "global_config")
-        )
-        global_row = result.scalar_one_or_none()
+        global_row = await _get_setting(session, "global_config", user.username)
 
         if global_row is not None:
             merged_data = {**global_row.data, **update_data}
             global_row.data = merged_data
         else:
-            global_row = Setting(category="global_config", data=update_data)
+            global_row = Setting(category="global_config", data=update_data, user_id=user.username)
             session.add(global_row)
 
     # --- Upsert generation_defaults ---
     if generation_update is not None:
-        result = await session.execute(
-            select(Setting).where(Setting.category == "generation_defaults")
-        )
-        gen_row = result.scalar_one_or_none()
+        gen_row = await _get_setting(session, "generation_defaults", user.username)
 
         if gen_row is not None:
             merged_gen = {**gen_row.data, **generation_update}
             gen_row.data = merged_gen
         else:
-            gen_row = Setting(category="generation_defaults", data=generation_update)
+            gen_row = Setting(category="generation_defaults", data=generation_update, user_id=user.username)
             session.add(gen_row)
 
     await session.commit()
@@ -249,7 +261,7 @@ async def update_settings(
     get_config.cache_clear()
 
     # Re-read from DB and merge onto fresh config for response
-    db_data = await _load_db_settings(session)
+    db_data = await _load_db_settings(session, user.username)
     has_db_keys = any(k in db_data for k in _API_KEY_FIELDS)
     fresh_config = GeneConfig()
     merged = _merge_db_onto_config(fresh_config, db_data)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
-import { lazy, Suspense } from 'react'
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { lazy, Suspense, useEffect, useState } from 'react'
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ErrorBoundary } from './components/layout/ErrorBoundary'
 import AppShell from './components/layout/AppShell'
 import { PromptLayout } from './components/layout/PromptLayout'
 import PromptsPage from './pages/PromptsPage'
+import { isAuthenticated } from './lib/auth'
+import { getApiBaseUrl } from './lib/api-config'
 
 // Route-based code splitting: each page loads only when navigated to
 const PromptTemplatePage = lazy(() => import('./pages/PromptTemplatePage'))
@@ -16,8 +18,38 @@ const RunDetailPage = lazy(() => import('./pages/RunDetailPage'))
 const PromptPlaygroundPage = lazy(() => import('./pages/PromptPlaygroundPage'))
 const WizardPage = lazy(() => import('./pages/WizardPage'))
 const SettingsPage = lazy(() => import('./pages/SettingsPage'))
+const LoginPage = lazy(() => import('./pages/LoginPage'))
 
 const queryClient = new QueryClient()
+
+/**
+ * Auth guard that checks /api/auth/status to determine if login is required.
+ * When auth is disabled on the backend, all routes are accessible without login.
+ */
+function RequireAuth({ children }: { children: React.ReactNode }) {
+  const location = useLocation()
+  const [authRequired, setAuthRequired] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    fetch(`${getApiBaseUrl()}/api/auth/status`)
+      .then(r => r.json())
+      .then(data => setAuthRequired(data.auth_required))
+      .catch(() => setAuthRequired(false))
+  }, [])
+
+  // Still loading auth status
+  if (authRequired === null) return null
+
+  // Auth not required by backend — allow through
+  if (!authRequired) return <>{children}</>
+
+  // Auth required but user not logged in — redirect to login
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  return <>{children}</>
+}
 
 function PageFallback() {
   return (
@@ -34,7 +66,8 @@ export default function App() {
       <BrowserRouter>
         <Suspense fallback={<PageFallback />}>
         <Routes>
-          <Route element={<AppShell />}>
+          <Route path="/login" element={<LoginPage />} />
+          <Route element={<RequireAuth><AppShell /></RequireAuth>}>
             <Route path="/prompts" element={<PromptsPage />} />
             <Route path="/wizard" element={<WizardPage />} />
             <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/datasets/SynthesisDialog.tsx
+++ b/frontend/src/components/datasets/SynthesisDialog.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { getApiBaseUrl, getWsBaseUrl } from '@/lib/api-config'
+import { getToken } from '@/lib/auth'
 import { UserPlus, Download, Upload, Wrench, Sparkles, X, Check, AlertCircle } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { PersonaCard, type Persona } from './PersonaCard'
@@ -363,7 +364,9 @@ export function SynthesisDialog({ promptId, open, onOpenChange, onComplete }: Sy
 
   function connectWebSocket(synthesisRunId: string, isReconnect = false) {
     const wsBase = getWsBaseUrl()
-    const ws = new WebSocket(`${wsBase}/ws/synthesis/${synthesisRunId}`)
+    const token = getToken()
+    const tokenParam = token ? `?token=${encodeURIComponent(token)}` : ''
+    const ws = new WebSocket(`${wsBase}/ws/synthesis/${synthesisRunId}${tokenParam}`)
     wsRef.current = ws
 
     ws.onmessage = (event) => {

--- a/frontend/src/hooks/useEvolutionSocket.ts
+++ b/frontend/src/hooks/useEvolutionSocket.ts
@@ -5,6 +5,7 @@ import type {
   RawEvolutionEvent,
 } from '../types/evolution';
 import { getWsBaseUrl } from '../lib/api-config';
+import { getToken } from '../lib/auth';
 
 export const initialState: EvolutionState = {
   status: 'idle',
@@ -182,7 +183,9 @@ export function useEvolutionSocket(runId: string | null): EvolutionState {
     dispatch({ type: 'ws_connecting' });
 
     const wsBase = getWsBaseUrl();
-    const ws = new WebSocket(`${wsBase}/ws/evolution/${runId}`);
+    const token = getToken();
+    const tokenParam = token ? `?token=${encodeURIComponent(token)}` : '';
+    const ws = new WebSocket(`${wsBase}/ws/evolution/${runId}${tokenParam}`);
     wsRef.current = ws;
 
     ws.onmessage = (event) => {

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,31 @@
+/**
+ * JWT authentication utilities for Helix frontend.
+ *
+ * Stores the JWT in localStorage and provides helpers for
+ * checking auth state, login/register API calls, and logout.
+ */
+
+const TOKEN_KEY = 'helix_jwt'
+const USERNAME_KEY = 'helix_username'
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY)
+}
+
+export function setToken(token: string, username: string): void {
+  localStorage.setItem(TOKEN_KEY, token)
+  localStorage.setItem(USERNAME_KEY, username)
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY)
+  localStorage.removeItem(USERNAME_KEY)
+}
+
+export function getUsername(): string | null {
+  return localStorage.getItem(USERNAME_KEY)
+}
+
+export function isAuthenticated(): boolean {
+  return !!getToken()
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,9 +5,30 @@ import './index.css'
 import App from './App.tsx'
 import { client } from './client/client.gen'
 import { getApiBaseUrl } from './lib/api-config'
+import { getToken, clearToken } from './lib/auth'
 
 // Configure @hey-api client with dynamic base URL from VITE_API_URL
 client.setConfig({ baseUrl: getApiBaseUrl() })
+
+// Add JWT auth header to all API requests
+client.interceptors.request.use((request) => {
+  const token = getToken()
+  if (token) {
+    request.headers.set('Authorization', `Bearer ${token}`)
+  }
+  return request
+})
+
+// Handle 401 globally — clear token and redirect to login
+client.interceptors.response.use((response) => {
+  if (response.status === 401) {
+    clearToken()
+    if (window.location.pathname !== '/login') {
+      window.location.href = '/login'
+    }
+  }
+  return response
+})
 
 // Theme is initialized in index.html <script> to prevent FOUC.
 // It reads localStorage('helix-theme') or falls back to system preference.

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Dna } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { setToken } from '@/lib/auth'
+import { getApiBaseUrl } from '@/lib/api-config'
+
+export default function LoginPage() {
+  const navigate = useNavigate()
+  const [isRegister, setIsRegister] = useState(false)
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    const endpoint = isRegister ? '/api/auth/register' : '/api/auth/login'
+    const body: Record<string, string> = { username, password }
+    if (isRegister && email) body.email = email
+
+    try {
+      const resp = await fetch(`${getApiBaseUrl()}${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({ detail: 'Request failed' }))
+        setError(data.detail || `Error ${resp.status}`)
+        return
+      }
+
+      const data = await resp.json()
+      setToken(data.access_token, data.username)
+      navigate('/prompts', { replace: true })
+    } catch {
+      setError('Could not connect to server')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center space-y-2">
+          <div className="flex items-center justify-center gap-2">
+            <Dna className="h-7 w-7 text-primary" />
+            <span className="text-2xl font-bold text-foreground">Helix</span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {isRegister ? 'Create your account' : 'Sign in to continue'}
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="username" className="text-sm font-medium text-foreground">
+                Username
+              </label>
+              <Input
+                id="username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="username"
+                required
+                autoComplete="username"
+                autoFocus
+              />
+            </div>
+
+            {isRegister && (
+              <div className="space-y-2">
+                <label htmlFor="email" className="text-sm font-medium text-foreground">
+                  Email <span className="text-muted-foreground">(optional)</span>
+                </label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="email@example.com"
+                  autoComplete="email"
+                />
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium text-foreground">
+                Password
+              </label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="password"
+                required
+                autoComplete={isRegister ? 'new-password' : 'current-password'}
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Loading...' : isRegister ? 'Create Account' : 'Sign In'}
+            </Button>
+
+            <p className="text-center text-sm text-muted-foreground">
+              {isRegister ? 'Already have an account?' : "Don't have an account?"}{' '}
+              <button
+                type="button"
+                onClick={() => { setIsRegister(!isRegister); setError(null) }}
+                className="text-primary hover:underline font-medium"
+              >
+                {isRegister ? 'Sign in' : 'Register'}
+              </button>
+            </p>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/tests/storage/test_db_models.py
+++ b/tests/storage/test_db_models.py
@@ -22,7 +22,7 @@ class TestSettingModel:
 
         mapper = sa_inspect(Setting)
         column_names = {c.key for c in mapper.column_attrs}
-        assert {"id", "category", "data"}.issubset(column_names)
+        assert {"id", "category", "data", "user_id"}.issubset(column_names)
 
     def test_id_is_primary_key(self):
         from api.storage.models import Setting
@@ -31,11 +31,11 @@ class TestSettingModel:
         pk_cols = [c.name for c in mapper.primary_key]
         assert "id" in pk_cols
 
-    def test_category_is_unique(self):
+    def test_has_user_id_column(self):
         from api.storage.models import Setting
 
-        col = Setting.__table__.columns["category"]
-        assert col.unique is True
+        col = Setting.__table__.columns["user_id"]
+        assert col.nullable is True
 
     def test_data_is_json(self):
         from api.storage.models import Setting


### PR DESCRIPTION
## Summary
- Login/register page with branded Helix UI (`/login` route)
- JWT auth interceptor on all API requests (Bearer header)
- Auth guard checks `GET /api/auth/status` — when auth is disabled, login is bypassed
- Per-user settings: `user_id` column on Setting table, queries scoped by user
- WebSocket connections pass JWT as `?token=` query param
- Global 401 handler redirects to login

## How it works
- `HELIX_AUTH_DISABLED=true` (default): no login required, everything works as before
- `HELIX_AUTH_DISABLED=false`: frontend shows login page, all API calls include JWT, settings scoped per user

## Cross-component check
- [x] Backend: 1208 tests pass
- [x] Frontend: 181 tests pass, build clean
- [x] CLI: unaffected (no web layer imports)
- [x] WebSocket hooks updated (useEvolutionSocket, SynthesisDialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)